### PR TITLE
feat: set up CPU/GPU cluster with node autoscaler support

### DIFF
--- a/scripts/gcp/create_corgie_igneous_cluster.py
+++ b/scripts/gcp/create_corgie_igneous_cluster.py
@@ -2,9 +2,10 @@
 import argparse
 import subprocess
 
-CREATE_COMMAND_TMPL = 'gcloud beta container --project "{PROJECT_NAME}" clusters create "{CLUSTER_NAME}" --region "{REGION}" --no-enable-basic-auth --release-channel "regular" --machine-type "e2-highmem-4" --image-type "COS_CONTAINERD" --disk-type "pd-standard" --disk-size "64" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_write","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/pubsub","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --max-pods-per-node "16" --preemptible --num-nodes "1" --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM --enable-ip-alias --network "projects/{PROJECT_NAME}/global/networks/default" --subnetwork "projects/{PROJECT_NAME}/regions/{REGION}/subnetworks/default" --no-enable-intra-node-visibility --default-max-pods-per-node "16" --enable-dataplane-v2 --no-enable-master-authorized-networks --addons HorizontalPodAutoscaling,GcePersistentDiskCsiDriver --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 --maintenance-window-start "2022-01-19T05:00:00Z" --maintenance-window-end "2022-01-20T05:00:00Z" --maintenance-window-recurrence "FREQ=WEEKLY;BYDAY=SA,SU" --labels owner={USERNAME} --workload-pool "{PROJECT_NAME}.svc.id.goog" --enable-shielded-nodes --node-locations {NODE_LOCATIONS}'
+CREATE_COMMAND_TMPL = 'gcloud beta container --project "{PROJECT_NAME}" clusters create "{CLUSTER_NAME}" --region "{REGION}" --no-enable-basic-auth --release-channel "regular" --machine-type "e2-medium" --image-type "COS_CONTAINERD" --disk-type "pd-standard" --disk-size "10" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_write","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/pubsub","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --max-pods-per-node "16" --preemptible --num-nodes "1" --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM --enable-ip-alias --network "projects/{PROJECT_NAME}/global/networks/default" --subnetwork "projects/{PROJECT_NAME}/regions/{REGION}/subnetworks/default" --no-enable-intra-node-visibility --default-max-pods-per-node "16" --enable-dataplane-v2 --no-enable-master-authorized-networks --addons HorizontalPodAutoscaling,GcePersistentDiskCsiDriver --enable-autoupgrade --enable-autorepair --max-surge-upgrade 0 --max-unavailable-upgrade 1 --maintenance-window-start "2022-01-19T05:00:00Z" --maintenance-window-end "2022-01-20T05:00:00Z" --maintenance-window-recurrence "FREQ=WEEKLY;BYDAY=SA,SU" --labels owner={USERNAME} --workload-pool "{PROJECT_NAME}.svc.id.goog" --enable-shielded-nodes --node-locations {NODE_LOCATIONS}'
 
-ADD_GPU_COMMAND_TMPL = 'gcloud beta container --project "{PROJECT_NAME}" node-pools create "gpu-n1-highmem-4-t4" --cluster "{CLUSTER_NAME}" --region "{REGION}" --machine-type "n1-highmem-4" --accelerator "type=nvidia-tesla-t4,count=1" --image-type "COS_CONTAINERD" --disk-type "pd-standard" --disk-size "64" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_write","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/pubsub","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --preemptible --num-nodes "1" --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 --max-pods-per-node "16" --node-locations {NODE_LOCATIONS}'
+ADD_CPU_COMMAND_TMPL = 'gcloud beta container --project "{PROJECT_NAME}" node-pools create "cpu-e2-highmem-4" --cluster "{CLUSTER_NAME}" --region "{REGION}" --machine-type "e2-highmem-4" --image-type "COS_CONTAINERD" --disk-type "pd-standard" --disk-size "64" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_write","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/pubsub","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --preemptible --num-nodes "1" --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 --max-pods-per-node "16" --node-locations {NODE_LOCATIONS} --enable-autoscaling --num-nodes 0 --total-min-nodes=0 --total-max-nodes=10 --node-taints=worker-pool=true:NoSchedule'
+ADD_GPU_COMMAND_TMPL = 'gcloud beta container --project "{PROJECT_NAME}" node-pools create "gpu-n1-highmem-4-t4" --cluster "{CLUSTER_NAME}" --region "{REGION}" --machine-type "n1-highmem-4" --accelerator "type=nvidia-tesla-t4,count=1" --image-type "COS_CONTAINERD" --disk-type "pd-standard" --disk-size "64" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_write","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/pubsub","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --preemptible --num-nodes "1" --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 --max-pods-per-node "16" --node-locations {NODE_LOCATIONS} --enable-autoscaling --num-nodes 0 --total-min-nodes=0 --total-max-nodes=10 --node-taints=worker-pool=true:NoSchedule'
 
 CONFIGURE_DRIVERS_COMMAND_TMPL = "gcloud container clusters get-credentials {CLUSTER_NAME} --region {REGION} --project {PROJECT_NAME}; kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml"
 
@@ -55,25 +56,42 @@ def main():
         default="c,d",
         help='GCP Zones for GPU node locations (e.g. "c,d" for us-east1-c, and us-east1-d).',
     )
+    parser.add_argument("--add_cpu", action="store_true", help="Add CPU node pool.")
     parser.add_argument("--add_gpu", action="store_true", help="Add GPU node pool.")
 
     args = parser.parse_args()
     # cluster_version = args.cluster_version
     # if cluster_version is None:
 
-    gpu_zones = [f"{args.region}-{zone_letter}" for zone_letter in args.gpu_zones.split(",")]
-    cpu_zones = [f"{args.region}-{zone_letter}" for zone_letter in args.cpu_zones.split(",")]
+    if args.add_cpu:
+        system_zone = f"{args.region}-{args.cpu_zones.split(',')[0]}"
+    elif args.add_gpu:
+        system_zone = f"{args.region}-{args.gpu_zones.split(',')[0]}"
+    else:
+        print("Neither CPU nor GPU cluster requested.")
+        return
 
     create_command = CREATE_COMMAND_TMPL
     create_command = create_command.replace("{REGION}", args.region)
     create_command = create_command.replace("{USERNAME}", args.username)
     create_command = create_command.replace("{PROJECT_NAME}", args.project_name)
     create_command = create_command.replace("{CLUSTER_NAME}", args.cluster_name)
-    create_command = create_command.replace("{NODE_LOCATIONS}", ",".join(cpu_zones))
+    create_command = create_command.replace("{NODE_LOCATIONS}", system_zone)
     print(f"Running: \n{create_command}")
     subprocess.call(create_command, shell=True)
 
+    if args.add_cpu:
+        cpu_zones = [f"{args.region}-{zone_letter}" for zone_letter in args.cpu_zones.split(",")]
+        add_cpu_command = ADD_CPU_COMMAND_TMPL
+        add_cpu_command = add_cpu_command.replace("{REGION}", args.region)
+        add_cpu_command = add_cpu_command.replace("{PROJECT_NAME}", args.project_name)
+        add_cpu_command = add_cpu_command.replace("{CLUSTER_NAME}", args.cluster_name)
+        add_cpu_command = add_cpu_command.replace("{NODE_LOCATIONS}", ",".join(cpu_zones))
+        print(f"Running: \n{add_cpu_command}")
+        subprocess.call(add_cpu_command, shell=True)
+
     if args.add_gpu:
+        gpu_zones = [f"{args.region}-{zone_letter}" for zone_letter in args.gpu_zones.split(",")]
         add_gpu_command = ADD_GPU_COMMAND_TMPL
         add_gpu_command = add_gpu_command.replace("{REGION}", args.region)
         add_gpu_command = add_gpu_command.replace("{PROJECT_NAME}", args.project_name)

--- a/zetta_utils/mazepa_addons/resource_allocation/gcp_k8s.py
+++ b/zetta_utils/mazepa_addons/resource_allocation/gcp_k8s.py
@@ -110,6 +110,14 @@ def get_worker_deployment_spec(
                             ],
                         }
                     ],
+                    "tolerations": [
+                        {
+                            "key": "worker-pool",
+                            "operator": "Equal",
+                            "value": "true",
+                            "effect": "NoSchedule"
+                        }
+                    ],
                     "dnsPolicy": "Default",
                     "restartPolicy": "Always",
                     "schedulerName": "default-scheduler",


### PR DESCRIPTION
* add a tiny separate node pool to run system pods for autoscaler
* add Taint `worker-pool` to CPU/GPU node pools to prevent system pods from getting scheduled on worker nodes
* add Toleration for `worker-pool` taint to mazepa generated deployments