### PR TITLE
fix: Ensure Vec3D for point annotation

### DIFF
--- a/zetta_utils/parsing/ngl_state.py
+++ b/zetta_utils/parsing/ngl_state.py
@@ -70,7 +70,7 @@ def _parse_annotations(layer: AnnotationLayer) -> List[Union[BBox3D, Vec3D]]:
             )
             result.append(bbox)
         except AttributeError:
-            point: Vec3D = annotation.point * resolution
+            point = Vec3D(*annotation.point) * Vec3D(*resolution)
             result.append(point)
     return result
 


### PR DESCRIPTION
Both, `annotation.point` and `resolution` are of type `ndarray`, causing the dynamic typechecker to complain in `VolumetricNGLIndexer`