### PR TITLE
fix: swap to headless OpenCV to avoid Qt/WSL/XServer issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ viz = [
     "zetta_utils[tensor_ops]",
     "matplotlib >= 3.5.2",
     "ipywidgets >= 7.7.0",
-    "opencv-python >= 4.5.5"
+    "opencv-python-headless >= 4.5.5"
 ]
 cloudvol = [
     "cloud-files== 4.11.0",


### PR DESCRIPTION
There is some weirdness with OpenCV requiring an XServer running - initially my local training simply wouldn't start without error message. Starting an XServer, it failed loading the Qt backend...

Since we don't rely on any OpenCV GUI stuff, would it be OK to just switch to the headless version?