### PR TITLE
fix: restore 7f8abe2

### DIFF
--- a/zetta_utils/geometry/vec.py
+++ b/zetta_utils/geometry/vec.py
@@ -24,7 +24,7 @@ N = TypeVar("N", bound=NDType)
 T_co = TypeVar("T_co", covariant=True, bound=DType)
 
 
-class _VecND(Generic[N, T_co], abc.Sequence):
+class _VecND(Generic[N, T_co], abc.Sequence[T_co]):
     """
     The backend primitive for an N-dimensional vector. This class should not be used or
     its constructor called directly. Use `VecND`, `IntVecND` to type annotate arbitrarily

--- a/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
@@ -130,9 +130,9 @@ def build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg,
         if processing_region % processing_chunk_size != IntVec3D(0, 0, 0):
             n_region_chunks = processing_region / processing_chunk_size
             n_region_chunks_rounded = IntVec3D(*(round(e) for e in n_region_chunks))
-            if processing_region % n_region_chunks_rounded == Vec3D(0, 0, 0):
+            if processing_region % n_region_chunks_rounded == IntVec3D(0, 0, 0):
                 rec_processing_chunk_size = IntVec3D(
-                    *(processing_region / n_region_chunks_rounded)
+                    *(processing_region // n_region_chunks_rounded)
                 )
                 rec_str = f"Recommendation for `processing_chunk_size[level]`: {rec_processing_chunk_size}"
             else:


### PR DESCRIPTION
The Sequence type condition got lost somewhere in #245.
mypy doesn't complain about the missing `T_co`, but pylance does in a cryptic `Cannot create consistent method ordering` message.