### PR TITLE
feat: ChainIndexer to chain SampleIndexers

### DIFF
--- a/docs/source/zetta_utils.training.rst
+++ b/docs/source/zetta_utils.training.rst
@@ -8,6 +8,8 @@
 
 .. autoclass:: zetta_utils.training.datasets.JointDataset
 
+.. autoclass:: zetta_utils.training.datasets.sample_indexers.ChainIndexer
+
 .. autoclass:: zetta_utils.training.datasets.sample_indexers.RandomIndexer
 
 .. autoclass:: zetta_utils.training.datasets.sample_indexers.VolumetricStridedIndexer

--- a/tests/unit/training/datasets/test_chain_indexer.py
+++ b/tests/unit/training/datasets/test_chain_indexer.py
@@ -1,0 +1,55 @@
+# pylint: disable=missing-docstring,redefined-outer-name,unused-argument,pointless-statement,line-too-long,protected-access,unsubscriptable-object
+import pytest
+
+from zetta_utils.geometry import BBox3D, IntVec3D, Vec3D
+from zetta_utils.training.datasets.sample_indexers import (
+    ChainIndexer,
+    VolumetricStridedIndexer,
+)
+
+
+def _gen_chain():
+    vsi_1 = VolumetricStridedIndexer(
+        bbox=BBox3D.from_coords(
+            start_coord=Vec3D(0, 0, 0), end_coord=Vec3D(1, 2, 3), resolution=Vec3D(1, 1, 1)
+        ),
+        chunk_size=IntVec3D(1, 1, 1),
+        resolution=Vec3D(1, 1, 1),
+        stride=IntVec3D(1, 1, 1),
+    )
+    vsi_2 = VolumetricStridedIndexer(
+        bbox=BBox3D.from_coords(
+            start_coord=Vec3D(10, 10, 10), end_coord=Vec3D(10, 10, 10), resolution=Vec3D(1, 1, 1)
+        ),
+        chunk_size=IntVec3D(1, 1, 1),
+        resolution=Vec3D(1, 1, 1),
+        stride=IntVec3D(1, 1, 1),
+    )
+    vsi_3 = VolumetricStridedIndexer(
+        bbox=BBox3D.from_coords(
+            start_coord=Vec3D(10, 10, 10), end_coord=Vec3D(11, 12, 12), resolution=Vec3D(1, 1, 1)
+        ),
+        chunk_size=IntVec3D(1, 1, 1),
+        resolution=Vec3D(1, 1, 1),
+        stride=IntVec3D(1, 1, 1),
+    )
+    return ChainIndexer([vsi_1, vsi_2, vsi_3])
+
+
+def test_len(mocker):
+    vsi_chain = _gen_chain()
+    assert len(vsi_chain) == 10
+
+
+def test_call(mocker):
+    vsi_chain = _gen_chain()
+    assert vsi_chain(0) == (None, slice(0, 1), slice(0, 1), slice(0, 1))
+    assert vsi_chain(6) == (None, slice(10, 11), slice(10, 11), slice(10, 11))
+
+
+def test_call_error(mocker):
+    vsi_chain = _gen_chain()
+    with pytest.raises(ValueError):
+        vsi_chain(10)
+    with pytest.raises(ValueError):
+        vsi_chain(-1)

--- a/zetta_utils/training/datasets/sample_indexers/__init__.py
+++ b/zetta_utils/training/datasets/sample_indexers/__init__.py
@@ -4,6 +4,7 @@ Mappings between integer index id and the corresponding index for querying data.
 
 from . import base, random_indexer, volumetric_strided_indexer
 from .base import SampleIndexer
+from .chain_indexer import ChainIndexer
 from .random_indexer import RandomIndexer
 from .volumetric_strided_indexer import VolumetricStridedIndexer
 from .loop_indexer import LoopIndexer

--- a/zetta_utils/training/datasets/sample_indexers/chain_indexer.py
+++ b/zetta_utils/training/datasets/sample_indexers/chain_indexer.py
@@ -1,0 +1,46 @@
+import bisect
+from itertools import accumulate
+from typing import Any, Sequence
+
+import attrs
+from typeguard import typechecked
+
+from zetta_utils import builder
+
+from .base import SampleIndexer
+
+
+@builder.register("ChainIndexer")
+@typechecked
+@attrs.frozen
+class ChainIndexer(SampleIndexer):
+    """
+    Iterates over a sequence of inner indexers.
+
+    :param inner_indexer: Sequence of inner indexers.
+    """
+
+    inner_indexer: Sequence[SampleIndexer]
+    num_samples: list[int] = attrs.field(init=False)
+
+    def __attrs_post_init__(self):
+        # Use `__setattr__` to keep the object frozen.
+        num_samples = [0] + list(accumulate(len(indexer) for indexer in self.inner_indexer))
+        object.__setattr__(self, "num_samples", num_samples)
+
+    def __len__(self):
+        return self.num_samples[-1]
+
+    def __call__(self, idx: int) -> Any:
+        """Yield a sample index from an indexer given a index.
+
+        :param idx: Integer sample index.
+        :return: Index of the type used by the wrapped inner indexer.
+        """
+        if idx not in range(0, len(self)):
+            raise ValueError(f"idx expected to be in range [0, {len(self)}), but got {idx}.")
+
+        inner_indexer = bisect.bisect_right(self.num_samples, idx) - 1
+        inner_index = idx - self.num_samples[inner_indexer]
+
+        return self.inner_indexer[inner_indexer](inner_index)


### PR DESCRIPTION
A similar behavior would also be possible with Vertical Joint Datasets, but having a dedicated chain indexer should help keep the spec files more readable.