### PR TITLE
New specs and updated BaseEncode regime

### DIFF
--- a/specs/nico/inference/cns/0_encoding_cns/M10_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M10_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img_masked"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1_masked2"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/7_M5_M10_conv5_lr0.0001_equi0.5_post1.06_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [256, 288, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 32
+#RESOLUTION: [4096, 4096, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 36864, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  10
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: true
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M11_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M11_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/6_M6_M11_conv5_lr0.0001_equi0.5_post1.1_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [128, 144, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 32
+#RESOLUTION: [8192, 8192, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 36864, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  10
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: true
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M12_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M12_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/6_M7_M12_conv5_lr0.0001_equi0.5_post1.1_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [64, 72, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 32
+#RESOLUTION: [16384, 16384, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 36864, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  10
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: true
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M3_generate_base_enc_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M3_generate_base_enc_cns.cue
@@ -1,0 +1,63 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_encodings/gamma_low0.75_high1.5_prob1.0_tile_0.0_0.2_lr0.00002_post1.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [2048, 2048, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+
+#RESOLUTION: [32, 32, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":         "mazepa.execute_on_gcp_with_sqs"
+worker_image:    "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas: 100
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseEncoder"
+			model_path: #MODEL_PATH
+		}
+		crop_pad: [32, 32, 0]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		info_chunk_size: #DST_INFO_CHUNK_SIZE
+		on_info_exists:  "overwrite"
+	}
+	idx: {
+		"@type": "VolumetricIndex"
+		bbox:    #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M4_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M4_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/3_M3_M4_conv1_unet3_lr0.0001_equi0.5_post1.6_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [1024, 1024, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 2
+#RESOLUTION: [#RES_MULT * 32, #RES_MULT * 32, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  100
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M5_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M5_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/3_M3_M5_conv2_unet2_lr0.0001_equi0.5_post1.4_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [1024, 1024, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 4
+#RESOLUTION: [#RES_MULT * 32, #RES_MULT * 32, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  100
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M6_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M6_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/4_M3_M6_conv3_unet1_lr0.0001_equi0.5_post1.1_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [1024, 1024, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 8
+#RESOLUTION: [#RES_MULT * 32, #RES_MULT * 32, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  100
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M7_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M7_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/5_M3_M7_conv4_lr0.0001_equi0.5_post1.03_fmt0.8_cns_all/epoch=0-step=1584-backup.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [1024, 1024, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 16
+#RESOLUTION: [#RES_MULT * 32, #RES_MULT * 32, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  10
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M8_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M8_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/5_M3_M8_conv5_lr0.0001_equi0.5_post1.03_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [1024, 1024, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 32
+#RESOLUTION: [#RES_MULT * 32, #RES_MULT * 32, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  10
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/M9_encoder_coarsener_chunked_cns.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/M9_encoder_coarsener_chunked_cns.cue
@@ -1,0 +1,67 @@
+// #SRC_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+#SRC_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+#DST_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+
+#MODEL_PATH: "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/5_M4_M9_conv5_lr0.00002_equi0.5_post1.1_fmt0.8_cns_all/last.ckpt.model.spec.json"
+
+#CHUNK_SIZE: [512, 512, 1]
+
+#DST_INFO_CHUNK_SIZE: [1024, 1024, 1]
+
+#RES_MULT: 32
+#RESOLUTION: [2048, 2048, 45]
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [0, 0, 3300]
+	end_coord: [32768, 32768, 3501]
+	resolution: [32, 32, 45]
+}
+
+"@type":          "mazepa.execute_on_gcp_with_sqs"
+worker_image:     "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_replicas:  10
+worker_resources: {
+	"nvidia.com/gpu": "1"
+}
+
+local_test: false
+
+target: {
+	"@type": "build_chunked_apply_flow"
+	operation: {
+		"@type": "VolumetricCallableOperation"
+		fn: {
+			"@type":    "BaseCoarsener"
+			model_path: #MODEL_PATH
+			tile_pad_in: 128
+			tile_size: 1024
+			ds_factor: #RES_MULT
+		}
+		crop_pad: [128, 128, 0]
+		res_change_mult: [#RES_MULT, #RES_MULT, 1]
+	}
+	chunker: {
+		"@type":      "VolumetricIndexChunker"
+		"chunk_size": #CHUNK_SIZE
+	}
+	src: {
+		"@type": "build_cv_layer"
+		path:    #SRC_PATH
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		info_chunk_size:     #DST_INFO_CHUNK_SIZE
+		info_field_overrides: {
+			data_type: "int8"
+		}
+		on_info_exists: "expect_same"
+	}
+	idx: {
+		"@type":    "VolumetricIndex"
+		bbox:      #BBOX
+		resolution: #RESOLUTION
+	}
+}

--- a/specs/nico/inference/cns/0_encoding_cns/masking.cue
+++ b/specs/nico/inference/cns/0_encoding_cns/masking.cue
@@ -1,0 +1,101 @@
+#DEFECTS_PATH: "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/defect_mask"
+#RESIN_PATH:   "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/resin_mask"
+
+#IMG_PATH:        "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1"
+#IMG_MASKED_PATH: "gs://zetta_lee_fly_cns_001_alignment_temp/encodings/elastic_m3_m9_v1_masked"
+
+#BBOX: {
+    "@type": "BBox3D.from_coords"
+    start_coord: [0, 0, 3300]
+    end_coord: [2048, 2048, 3501]
+    resolution: [512, 512, 45]
+}
+#BIG_BBOX: {
+    "@type": "BBox3D.from_coords"
+    start_coord: [0, 0, 3300]
+    end_coord: [1024 * 8, 1024 * 8, 3501]
+    resolution: [512, 512, 45]
+}
+
+#FLOW_TMPL: {
+    "@type":        "build_apply_mask_flow"
+    chunk_size:     _
+    dst_resolution: _
+    src: {
+        "@type": "build_cv_layer"
+        path:    _
+    }
+    masks: [
+        {
+            "@type": "build_cv_layer"
+            path:    #DEFECTS_PATH
+            read_procs: [
+                {
+                    "@type": "coarsen_mask"
+                    "@mode": "partial"
+                    width:   1
+                },
+
+            ]
+        },
+        {
+            "@type": "build_cv_layer"
+            path:    #RESIN_PATH
+            data_resolution: [256, 256, 45]
+            interpolation_mode: "mask"
+        },
+    ]
+
+    dst: {
+        "@type":             "build_cv_layer"
+        path:                _
+        info_reference_path: src.path
+        on_info_exists:      "expect_same"
+    }
+    bbox: _
+}
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_masks"
+worker_resources: {
+    memory: "18560Mi"
+}
+worker_replicas:     100
+batch_gap_sleep_sec: 0.05
+
+local_test: false
+
+target: {
+    "@type": "mazepa.concurrent_flow"
+    stages: [
+        for res in [32, 64, 128] {
+            #FLOW_TMPL & {
+                chunk_size: [1024 * 4, 1024 * 4, 1]
+                bbox: #BBOX
+                dst_resolution: [res, res, 45]
+                src: path: #IMG_PATH
+                dst: path: #IMG_MASKED_PATH
+            }
+        },
+        for res in [256, 512] {
+            #FLOW_TMPL & {
+                chunk_size: [1024 * 2, 1024 * 2, 1]
+                bbox: #BBOX
+                dst_resolution: [res, res, 45]
+                src: path: #IMG_PATH
+                dst: path: #IMG_MASKED_PATH
+            }
+        },
+        for res in [1024, 2048, 4096] {
+            #FLOW_TMPL & {
+                chunk_size: [1024, 1024, 1]
+                bbox: #BIG_BBOX
+                dst_resolution: [res, res, 45]
+                src: path: #IMG_PATH
+                dst: path: #IMG_MASKED_PATH
+            }
+
+        },
+
+    ]
+}

--- a/specs/nico/training/cns/base_coarsener/1_m3_m4_conv1_unet3.cue
+++ b/specs/nico/training/cns/base_coarsener/1_m3_m4_conv1_unet3.cue
@@ -1,0 +1,328 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT_START_VAL:   2.0
+#POST_WEIGHT_START_STEP:  200
+#POST_WEIGHT_END_VAL:     1.03
+#POST_WEIGHT_END_STEP:    2200
+#FIELD_MAGN_THR: 0.8
+#LR:            2e-5
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "1.3_M3_M4_conv1_unet3_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT_START_VAL)-\(#POST_WEIGHT_END_VAL)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "1_M3_M4_conv1_unet3_lr0.0001_equi0.5_post1.6_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    null // "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight_start_step: #POST_WEIGHT_START_STEP
+		post_weight_end_step:   #POST_WEIGHT_END_STEP
+		post_weight_start_val:  #POST_WEIGHT_START_VAL
+		post_weight_end_val:    #POST_WEIGHT_END_VAL
+		ds_factor:              2
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d",
+						kernel_size: 2
+					},
+					{
+						"@type": "UNet"
+						list_num_channels: [
+							[32, 32, 32],
+							[32, 32, 32],
+							[32, 32, 32],
+
+							[32, 32, 32],
+
+							[32, 32, 32],
+							[32, 32, 32],
+							[32, 32, 1],
+						]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					}
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+							{
+								"@type": "VolumetricIndexTranslator"
+								offset: [0, 0, -1]
+								resolution: [4, 4, 45]
+							},
+						]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/1_m3_m4_unet3_conv1.cue
+++ b/specs/nico/training/cns/base_coarsener/1_m3_m4_unet3_conv1.cue
@@ -1,0 +1,322 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.6
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "2b_M3_M4_unet3_conv1_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "1_M3_M4_unet3_conv1_lr0.0001_equi0.5_post1.8_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              2
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "UNet"
+						list_num_channels: [
+							[1, 32, 32],
+							[32, 32, 32],
+							[32, 32, 32],
+
+							[32, 32, 32],
+
+							[32, 32, 32],
+							[32, 32, 32],
+							[32, 32, 32],
+						]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d",
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					}
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+							{
+								"@type": "VolumetricIndexTranslator"
+								offset: [0, 0, -1]
+								resolution: [4, 4, 45]
+							},
+						]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/2_m3_m5_conv2_unet2.cue
+++ b/specs/nico/training/cns/base_coarsener/2_m3_m5_conv2_unet2.cue
@@ -1,0 +1,337 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT_START_VAL:   1.8
+#POST_WEIGHT_START_STEP:  200
+#POST_WEIGHT_END_VAL:     1.03
+#POST_WEIGHT_END_STEP:    2200
+#FIELD_MAGN_THR: 0.8
+#LR:            2e-5
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "1.2_M3_M5_conv2_unet2_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT_START_VAL)-\(#POST_WEIGHT_END_VAL)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "1_M3_M5_conv2_unet2_lr0.0001_equi0.5_post1.4_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    null // "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight_start_step: #POST_WEIGHT_START_STEP
+		post_weight_end_step:   #POST_WEIGHT_END_STEP
+		post_weight_start_val:  #POST_WEIGHT_START_VAL
+		post_weight_end_val:    #POST_WEIGHT_END_VAL
+		ds_factor:              4
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d",
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "UNet"
+						list_num_channels: [
+							[32, 32, 32],
+							[32, 32, 32],
+
+							[32, 32, 32],
+
+							[32, 32, 32],
+							[32, 32, 1],
+						]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					}
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+							{
+								"@type": "VolumetricIndexTranslator"
+								offset: [0, 0, -1]
+								resolution: [4, 4, 45]
+							},
+						]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/2_m3_m5_unet2_conv2.cue
+++ b/specs/nico/training/cns/base_coarsener/2_m3_m5_unet2_conv2.cue
@@ -1,0 +1,331 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.3
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "4_M3_M5_unet2_conv2_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "3_M3_M5_unet2_conv2_lr0.0001_equi0.5_post1.5_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              4
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "UNet"
+						list_num_channels: [
+							[1, 32, 32],
+							[32, 32, 32],
+
+							[32, 32, 32],
+
+							[32, 32, 32],
+							[32, 32, 32],
+						]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d",
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					}
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+							{
+								"@type": "VolumetricIndexTranslator"
+								offset: [0, 0, -1]
+								resolution: [4, 4, 45]
+							},
+						]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/3_m3_m6_conv3_unet1.cue
+++ b/specs/nico/training/cns/base_coarsener/3_m3_m6_conv3_unet1.cue
@@ -1,0 +1,346 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT_START_VAL:   1.8
+#POST_WEIGHT_START_STEP:  200
+#POST_WEIGHT_END_VAL:     1.03
+#POST_WEIGHT_END_STEP:    2200
+#FIELD_MAGN_THR: 0.8
+#LR:            2e-5
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "1.1_M3_M6_conv3_unet1_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT_START_VAL)-\(#POST_WEIGHT_END_VAL)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "1_M3_M6_conv3_unet1_lr0.0001_equi0.5_post1.1_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    null // "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230213_2"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight_start_step: #POST_WEIGHT_START_STEP
+		post_weight_end_step:   #POST_WEIGHT_END_STEP
+		post_weight_start_val:  #POST_WEIGHT_START_VAL
+		post_weight_end_val:    #POST_WEIGHT_END_VAL
+		ds_factor:              8
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "UNet"
+						list_num_channels: [
+							[32, 32, 32],
+
+							[32, 32, 32],
+
+							[32, 32, 1],
+						]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/3_m3_m6_unet1_conv3.cue
+++ b/specs/nico/training/cns/base_coarsener/3_m3_m6_unet1_conv3.cue
@@ -1,0 +1,340 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.06
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "5_M3_M6_unet1_conv3_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "4_M3_M6_unet1_conv3_lr0.0001_equi0.5_post1.1_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              8
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "UNet"
+						list_num_channels: [
+							[1, 32, 32],
+
+							[32, 32, 32],
+
+							[32, 32, 32],
+						]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/4_m3_m7_conv4.cue
+++ b/specs/nico/training/cns/base_coarsener/4_m3_m7_conv4.cue
@@ -1,0 +1,346 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.03
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/fine_v4/M7_500xSM200_M6_500xSM200_M5_500xSM200_M4_250xSM200_M3_250xSM200_VV3_CT2.5_BS10/mip1/img/img_rendered"
+
+#EXP_VERSION:   "5_M3_M7_conv4_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "4_M3_M7_conv4_lr0.0001_equi0.5_post1.1_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              16
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [10 * 1024, 1 * 1024, 2502]
+				end_coord: [22 * 1024, 28 * 1024, 3500]
+				resolution: [32, 32, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/5_m3_m8_conv5.cue
+++ b/specs/nico/training/cns/base_coarsener/5_m3_m8_conv5.cue
@@ -1,0 +1,402 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.03
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [32, 32, 45]
+#SOURCE_PATH:   "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+
+#EXP_VERSION:   "5_M3_M8_conv5_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "4_M3_M8_conv5_lr0.0001_equi0.5_post1.1_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              32
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						activate_last: true
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "ChainIndexer"
+			inner_indexer: [
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [ 2 * 1024,  1 * 1024, 1001]
+						end_coord:   [29 * 1024, 10 * 1024, 2000]
+						resolution: [32, 32, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [10 * 1024, 15 * 1024, 1001]
+						end_coord:   [19 * 1024, 21 * 1024, 2000]
+						resolution: [32, 32, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [ 2 * 1024,  1 * 1024, 2501]
+						end_coord:   [28 * 1024,  9 * 1024, 3500]
+						resolution: [32, 32, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [10 * 1024,  9 * 1024, 2501]
+						end_coord:   [22 * 1024, 21 * 1024, 3500]
+						resolution: [32, 32, 45]
+					}
+				}
+			]
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [10 * 1024, 2 * 1024, 3182]
+			end_coord: [22 * 1024, 7 * 1024, 3184]
+			resolution: [32, 32, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/6_m4_m9_conv5.cue
+++ b/specs/nico/training/cns/base_coarsener/6_m4_m9_conv5.cue
@@ -1,0 +1,402 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.1
+#FIELD_MAGN_THR: 0.8
+#LR:            2e-5
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [64, 64, 45]
+#SOURCE_PATH:   "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+
+#EXP_VERSION:   "5_M4_M9_conv5_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "4_M4_M9_conv5_lr0.0001_equi0.5_post1.3_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    32.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              32
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						activate_last: true
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "ChainIndexer"
+			inner_indexer: [
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [ 1 * 1024,  0 * 1024, 1001]
+						end_coord:   [15 * 1024, 5 * 1024, 2000]
+						resolution: [64, 64, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [5 * 1024, 7 * 1024, 1001]
+						end_coord:   [10 * 1024, 11 * 1024, 2000]
+						resolution: [64, 64, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [ 1 * 1024,  0 * 1024, 2501]
+						end_coord:   [14 * 1024,  5 * 1024, 3500]
+						resolution: [64, 64, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [5 * 1024,  5 * 1024, 2501]
+						end_coord:   [11 * 1024, 11 * 1024, 3500]
+						resolution: [64, 64, 45]
+					}
+				}
+			]
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [2 * 1024,  1 * 1024, 3182]
+			end_coord:   [12 * 1024, 4 * 1024, 3186]
+			resolution: [64, 64, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/7_m5_m10_conv5.cue
+++ b/specs/nico/training/cns/base_coarsener/7_m5_m10_conv5.cue
@@ -1,0 +1,402 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.06
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [128, 128, 45]
+#SOURCE_PATH:   "gs://sergiy_exp/aced/demo_x0/rigid_to_elastic/raw_img"
+
+#EXP_VERSION:   "7_M5_M10_conv5_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "6_M5_M10_conv5_lr0.0001_equi0.5_post1.1_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:     "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    16.0
+		val_log_row_interval:   16
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              32
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						activate_last: true
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "ChainIndexer"
+			inner_indexer: [
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [ 0 * 1024,  0 * 1024, 1001]
+						end_coord:   [8 * 1024, 3 * 1024, 2000]
+						resolution: [128, 128, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [2 * 1024, 3 * 1024, 1001]
+						end_coord:   [5 * 1024, 6 * 1024, 2000]
+						resolution: [128, 128, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [ 0 * 1024,  0 * 1024, 2501]
+						end_coord:   [7 * 1024,  3 * 1024, 3500]
+						resolution: [128, 128, 45]
+					}
+				},
+				{
+					"@type": "VolumetricStridedIndexer"
+					resolution: #SOURCE_RES
+					desired_resolution: #SOURCE_RES
+					chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+					stride: [#CHUNK_XY, #CHUNK_XY, 1]
+					bbox: {
+						"@type":       "BBox3D.from_coords"
+						start_coord: [2 * 1024,  3 * 1024, 2501]
+						end_coord:   [6 * 1024, 6 * 1024, 3500]
+						resolution: [128, 128, 45]
+					}
+				}
+			]
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [1 * 1024,  0 * 1024, 3182]
+			end_coord:   [6 * 1024, 2 * 1024, 3190]
+			resolution: [128, 128, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/8_m6_m11_conv5.cue
+++ b/specs/nico/training/cns/base_coarsener/8_m6_m11_conv5.cue
@@ -1,0 +1,358 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.1
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [256, 256, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/elastic_low_res"
+
+#EXP_VERSION:   "6_M6_M11_conv5_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "5_M6_M11_conv5_lr0.0001_equi0.5_post1.3_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    8.0
+		val_log_row_interval:   24
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              32
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						activate_last: true
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [#CHUNK_XY, #CHUNK_XY, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [0, 0, 1]
+				end_coord: [2048, 2048, 7009]
+				resolution: [512, 512, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [0, 0, 3182]
+			end_coord: [2048, 2048, 3190]
+			resolution: [512, 512, 45]
+		}
+	}
+}

--- a/specs/nico/training/cns/base_coarsener/9_m7_m12_conv5.cue
+++ b/specs/nico/training/cns/base_coarsener/9_m7_m12_conv5.cue
@@ -1,0 +1,358 @@
+#EXP_NAME:      "base_coarsener_cns"
+#TRAINING_ROOT: "gs://zetta-research-nico/training_artifacts"
+#POST_WEIGHT:   1.1
+#FIELD_MAGN_THR: 0.8
+#LR:            1e-4
+#CLIP:          0e-5
+#K:             3
+#EQUI_WEIGHT:   0.5
+#CHUNK_XY:      1024
+#GAMMA_LOW:     0.5
+#GAMMA_HIGH:    1.5
+#GAMMA_PROB:    1.0
+#TILE_LOW:      0.0
+#TILE_HIGH:     0.2
+
+#SOURCE_RES:    [512, 512, 45]
+#SOURCE_PATH:   "gs://zetta_lee_fly_cns_001_alignment_temp/elastic_low_res"
+
+#EXP_VERSION:   "6_M7_M12_conv5_lr\(#LR)_equi\(#EQUI_WEIGHT)_post\(#POST_WEIGHT)_fmt\(#FIELD_MAGN_THR)_cns_all"
+
+#START_EXP_VERSION: "5_M7_M12_conv5_lr0.0001_equi0.5_post1.3_fmt\(#FIELD_MAGN_THR)_cns_all"
+#MODEL_CKPT:    "gs://zetta-research-nico/training_artifacts/base_coarsener_cns/\(#START_EXP_VERSION)/last.ckpt"
+
+"@type":      "mazepa.execute_on_gcp_with_sqs"
+worker_image: "us.gcr.io/zetta-research/zetta_utils:py3.9_torch_1.13.1_cu11.7_zu20230210"
+worker_resources: {
+	memory:           "18560Mi"
+	"nvidia.com/gpu": "1"
+}
+worker_replicas: 1
+local_test:      false
+
+target: {
+	"@type": "lightning_train"
+	"@mode": "partial"
+
+	regime: {
+		"@type":                "BaseCoarsenerRegime"
+		field_magn_thr:         #FIELD_MAGN_THR
+		max_displacement_px:    4.0
+		val_log_row_interval:   16
+		train_log_row_interval: 250
+		lr:                     #LR
+		equivar_weight:         #EQUI_WEIGHT
+		post_weight:            #POST_WEIGHT
+		ds_factor:              32
+		model: {
+			"@type": "load_weights_file"
+			model: {
+				"@type": "torch.nn.Sequential"
+				modules: [
+					{
+						"@type": "ConvBlock"
+						num_channels: [1, 32, 32]
+						activate_last: true
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 32]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: true
+					},
+					{
+						"@type":     "torch.nn.AvgPool2d"
+						kernel_size: 2
+					},
+					{
+						"@type": "ConvBlock"
+						num_channels: [32, 32, 1]
+						kernel_sizes: [#K, #K]
+						padding_modes: "reflect"
+						activate_last: false
+					},
+					{
+						"@type": "torch.nn.Tanh"
+					},
+				]
+			}
+			ckpt_path: #MODEL_CKPT
+			component_names: [
+				"model",
+			]
+		}
+	}
+	trainer: {
+		"@type":                 "ZettaDefaultTrainer"
+		accelerator:             "gpu"
+		devices:                 1
+		max_epochs:              1
+		default_root_dir:        #TRAINING_ROOT
+		experiment_name:         #EXP_NAME
+		experiment_version:      #EXP_VERSION
+		log_every_n_steps:       10
+		val_check_interval:      250
+		gradient_clip_algorithm: "norm"
+		gradient_clip_val:       #CLIP
+		checkpointing_kwargs: {
+			update_every_n_secs: 60
+			backup_every_n_secs: 900
+		}
+	}
+
+	train_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     true
+		num_workers: 4
+		dataset:     #train_dset
+	}
+	val_dataloader: {
+		"@type":     "TorchDataLoader"
+		batch_size:  1
+		shuffle:     false
+		num_workers: 4
+		dataset:     #val_dset
+	}
+}
+
+#IMG_PROCS: [
+	{
+		"@mode":   "partial"
+		"@type":   "rearrange"
+		"pattern": "c x y 1 -> c x y"
+	},
+	{
+		"@type": "divide"
+		"@mode": "partial"
+		value:   255.0
+	},
+	{
+		"@type": "gamma_contrast_aug"
+		"@mode": "partial"
+		prob:    #GAMMA_PROB
+		gamma_distr: {
+			"@type": "uniform_distr"
+			low:     #GAMMA_LOW
+			high:    #GAMMA_HIGH
+		}
+		max_magn: 1.0
+	},
+	{
+		"@type": "square_tile_pattern_aug"
+		"@mode": "partial"
+		prob:    1.0
+		tile_size: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		tile_stride: {
+			"@type": "uniform_distr"
+			low:     64
+			high:    1024
+		}
+		max_brightness_change: {
+			"@type": "uniform_distr"
+			low:     #TILE_LOW
+			high:    #TILE_HIGH
+		}
+		rotation_degree: {
+			"@type": "uniform_distr"
+			low:     0
+			high:    90
+		}
+		preserve_data_val: 0.0
+		repeats:           3
+		device:            "cpu"
+	},
+]
+
+#dset_settings: {
+	"@type":    "JointDataset"
+	mode:       "horizontal"
+	_img_procs: _
+	datasets: {
+		field: #FIELD_DSET
+		images: {
+			"@type": "LayerDataset"
+			layer: {
+				"@type": "build_layer_set"
+				layers: {
+					src: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+					}
+					tgt: {
+						"@type":    "build_cv_layer"
+						path:       #SOURCE_PATH
+						read_procs: _img_procs
+						index_procs: [
+                            {
+                                "@type": "VolumetricIndexTranslator"
+                                offset: [0, 0, -1]
+                                resolution: [4, 4, 45]
+                            },
+                        ]
+					}
+				}
+			}
+			"sample_indexer": _
+		}
+	}
+}
+
+#FIELD_DSET: {
+	"@type": "LayerDataset"
+	layer: {
+		"@type": "build_cv_layer"
+		path:    "gs://zetta-research-nico/perlin_noise_fields/1px"
+		read_procs: [
+			{
+				"@type":   "rearrange"
+				"@mode":   "partial"
+				"pattern": "c x y 1 -> c x y"
+			},
+		]
+	}
+	"sample_indexer": _
+}
+
+#field_indexer: {
+	"@type": "VolumetricStridedIndexer"
+	"bbox": {
+		"@type": "BBox3D.from_coords"
+		"end_coord": [
+			2048,
+			2048,
+			2040,
+		]
+		"resolution": [
+			4,
+			4,
+			45,
+		]
+		"start_coord": [
+			0,
+			0,
+			0,
+		]
+	}
+	"stride": [
+		1024,
+		1024,
+		1,
+	]
+	"chunk_size": [
+		#CHUNK_XY,
+		#CHUNK_XY,
+		1,
+	]
+	"resolution": [
+		4,
+		4,
+		45,
+	]
+	"desired_resolution": [
+		4,
+		4,
+		45,
+	]
+}
+
+#train_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: #IMG_PROCS
+	datasets: images: sample_indexer: {
+		"@type": "RandomIndexer"
+		inner_indexer: {
+			"@type": "VolumetricStridedIndexer"
+			resolution: #SOURCE_RES
+			desired_resolution: #SOURCE_RES
+			chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+			stride: [512, 512, 1]
+			bbox: {
+				"@type":       "BBox3D.from_coords"
+				start_coord: [0, 0, 1]
+				end_coord: [2048, 2048, 7009]
+				resolution: [512, 512, 45]
+			}
+		}
+	}
+}
+
+#val_dset: #dset_settings & {
+	datasets: field: sample_indexer: {
+		"@type":       "RandomIndexer"
+		inner_indexer: #field_indexer
+	}
+	_img_procs: [
+		{
+			"@mode":   "partial"
+			"@type":   "rearrange"
+			"pattern": "c x y 1 -> c x y"
+		},
+		{
+			"@type": "divide"
+			"@mode": "partial"
+			value:   255.0
+		},
+	]
+	datasets: images: sample_indexer: {
+		"@type": "VolumetricStridedIndexer"
+		resolution: #SOURCE_RES
+		desired_resolution: #SOURCE_RES
+		chunk_size: [#CHUNK_XY, #CHUNK_XY, 1]
+		stride: [#CHUNK_XY, #CHUNK_XY, 1]
+		bbox: {
+			"@type":       "BBox3D.from_coords"
+			start_coord: [0, 0, 3180]
+			end_coord: [2048, 2048, 3200]
+			resolution: [512, 512, 45]
+		}
+	}
+}

--- a/zetta_utils/alignment/__init__.py
+++ b/zetta_utils/alignment/__init__.py
@@ -1,7 +1,5 @@
-from . import field
-from . import online_finetuner
-from . import aced_relaxation
-from .base_encoder import BaseEncoder
+from . import aced_relaxation, field, online_finetuner
 from .base_coarsener import BaseCoarsener
+from .base_encoder import BaseEncoder
 from .encoding_coarsener import EncodingCoarsener
 from .misalignment_detector import MisalignmentDetector

--- a/zetta_utils/alignment/__init__.py
+++ b/zetta_utils/alignment/__init__.py
@@ -2,5 +2,6 @@ from . import field
 from . import online_finetuner
 from . import aced_relaxation
 from .base_encoder import BaseEncoder
+from .base_coarsener import BaseCoarsener
 from .encoding_coarsener import EncodingCoarsener
 from .misalignment_detector import MisalignmentDetector

--- a/zetta_utils/alignment/base_coarsener.py
+++ b/zetta_utils/alignment/base_coarsener.py
@@ -1,0 +1,61 @@
+import attrs
+import einops
+import torch
+from typeguard import typechecked
+
+from zetta_utils import builder, convnet
+
+
+@builder.register("BaseCoarsener")
+@typechecked
+@attrs.mutable
+class BaseCoarsener:
+    # Input int8 [   -127 .. 127] or uint8 [0 .. 255]
+    # Output int8 Encodings [-127 .. 127]
+
+    # Don't create the model during initialization for efficient serialization
+    model_path: str
+    abs_val_thr: float = 0.005
+    ds_factor: int = 1
+    tile_pad_in: int = 128
+    tile_size: int = 1024
+
+    def __call__(self, src: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+
+            # load model during the call _with caching_
+            model = convnet.utils.load_model(self.model_path, device=device, use_cache=True)
+
+            # uint8 raw images or int8 encodings
+            if src.dtype == torch.int8:
+                data_in = src.float() / 127.0  # [-1.0 .. 1.0]
+            elif src.dtype == torch.uint8:
+                data_in = src.float() / 255.0  # [ 0.0 .. 1.0]
+            else:
+                raise ValueError(f"Unsupported src dtype: {src.dtype}")
+
+            data_in = einops.rearrange(data_in, "C X Y Z -> Z C X Y").to(device)
+            result = torch.zeros_like(data_in[..., :data_in.shape[-2] // self.ds_factor, :data_in.shape[-1] // self.ds_factor]).float()
+
+            tile_pad_out = self.tile_pad_in // self.ds_factor
+            tile_size_out = self.tile_size // self.ds_factor
+            for x in range(self.tile_pad_in, data_in.shape[-2] - self.tile_pad_in, self.tile_size):
+                xs = x - self.tile_pad_in
+                xe = x + self.tile_size + self.tile_pad_in
+                for y in range(self.tile_pad_in, data_in.shape[-1] - self.tile_pad_in, self.tile_size):
+                    ys = y - self.tile_pad_in
+                    ye = y + self.tile_size + self.tile_pad_in
+                    tile = data_in[:, :, xs:xe, ys:ye]
+                    if (tile != 0).sum() > 0.0:
+                        tile_result = model(tile)[:, :, tile_pad_out:-tile_pad_out, tile_pad_out:-tile_pad_out]
+                        result[:, :, x//self.ds_factor:x//self.ds_factor+tile_size_out, y//self.ds_factor:y//self.ds_factor+tile_size_out] = tile_result
+
+            result = einops.rearrange(result, "Z C X Y -> C X Y Z")
+
+            # Final layer assumed to be tanh
+            assert result.abs().max() <= 1
+            result[result.abs() < self.abs_val_thr] = 0
+            result = 127.0 * result
+
+            return result.round().type(torch.int8).clamp(-127, 127)

--- a/zetta_utils/training/lightning/regimes/__init__.py
+++ b/zetta_utils/training/lightning/regimes/__init__.py
@@ -1,9 +1,11 @@
-from . import naive_supervised
-from . import encoding_coarsener
-from . import encoding_coarsener_highres
-from . import encoding_coarsener_gen_x1
-from . import noop
-from . import base_encoder
-from . import base_coarsener
-from . import misalignment_detector
-from . import misalignment_detector_aced
+from . import (
+    base_coarsener,
+    base_encoder,
+    encoding_coarsener,
+    encoding_coarsener_gen_x1,
+    encoding_coarsener_highres,
+    misalignment_detector,
+    misalignment_detector_aced,
+    naive_supervised,
+    noop,
+)

--- a/zetta_utils/training/lightning/regimes/__init__.py
+++ b/zetta_utils/training/lightning/regimes/__init__.py
@@ -4,5 +4,6 @@ from . import encoding_coarsener_highres
 from . import encoding_coarsener_gen_x1
 from . import noop
 from . import base_encoder
+from . import base_coarsener
 from . import misalignment_detector
 from . import misalignment_detector_aced

--- a/zetta_utils/training/lightning/regimes/base_coarsener.py
+++ b/zetta_utils/training/lightning/regimes/base_coarsener.py
@@ -1,12 +1,12 @@
 # pragma: no cover
 # pylint: disable=too-many-locals
 
-from typing import Optional
 from math import log2
+from typing import Optional
 
 import attrs
-import pytorch_lightning as pl
 import cc3d
+import pytorch_lightning as pl
 import torch
 import torchfields
 import wandb

--- a/zetta_utils/training/lightning/regimes/base_coarsener.py
+++ b/zetta_utils/training/lightning/regimes/base_coarsener.py
@@ -1,0 +1,259 @@
+# pragma: no cover
+# pylint: disable=too-many-locals
+
+from typing import Optional
+from math import log2
+
+import attrs
+import pytorch_lightning as pl
+import cc3d
+import torch
+import torchfields
+import wandb
+
+from zetta_utils import builder, distributions, tensor_ops, viz
+
+
+@builder.register("BaseCoarsenerRegime")
+@attrs.mutable(eq=False)
+class BaseCoarsenerRegime(pl.LightningModule):  # pylint: disable=too-many-ancestors
+    model: torch.nn.Module
+    lr: float
+    train_log_row_interval: int = 200
+    val_log_row_interval: int = 25
+    field_magn_thr: float = 1
+    max_displacement_px: float = 16.0
+    post_weight_start_step: int = 0
+    post_weight_end_step: int = 0
+    post_weight_start_val: float = 1.5
+    post_weight_end_val: float = 1.5
+    zero_value: float = 0
+    worst_val_loss: float = attrs.field(init=False, default=0)
+    worst_val_sample: dict = attrs.field(init=False, factory=dict)
+    worst_val_sample_idx: Optional[int] = attrs.field(init=False, default=None)
+
+    equivar_weight: float = 1.0
+    equivar_rot_deg_distr: distributions.Distribution = distributions.uniform_distr(0, 360)
+    equivar_shear_deg_distr: distributions.Distribution = distributions.uniform_distr(-10, 10)
+    equivar_trans_px_distr: distributions.Distribution = distributions.uniform_distr(-10, 10)
+    equivar_scale_distr: distributions.Distribution = distributions.uniform_distr(0.9, 1.1)
+    ds_factor: int = 2
+    empty_tissue_threshold: float = 0.4
+    _training_step: int = 0
+
+    def __attrs_pre_init__(self):
+        super().__init__()
+
+    def __attrs_post_init__(self):
+        # Maybe figure out ds_factor by running the model
+        pass
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
+        return optimizer
+
+    @staticmethod
+    def log_results(mode: str, title_suffix: str = "", **kwargs):
+        wandb.log(
+            {
+                f"results/{mode}_{title_suffix}_slider": [
+                    wandb.Image(viz.rendering.Renderer()(v.squeeze()), caption=k)  # type: ignore
+                    for k, v in kwargs.items()
+                ]
+            }
+        )
+
+    def validation_epoch_end(self, _):
+        self.log_results(
+            "val",
+            "worst",
+            **self.worst_val_sample,
+        )
+        self.worst_val_loss = 0
+        self.worst_val_sample = {}
+        self.worst_val_sample_idx = None
+
+    def training_step(self, batch, batch_idx):  # pylint: disable=arguments-differ
+        log_row = batch_idx % self.train_log_row_interval == 0
+
+        with torchfields.set_identity_mapping_cache(True, clear_cache=False):
+            loss = self.compute_metroem_loss(batch=batch, mode="train", log_row=log_row)
+
+        return loss
+
+    def _get_warped(self, img, field):
+        img_padded = torch.nn.functional.pad(
+            img, (1, 1, 1, 1), value=self.zero_value
+        )  # TanH! - fill with output zero value
+        img_warped = field.from_pixels()(img)
+
+        zeros_padded = img_padded == self.zero_value
+        zeros_padded_cc = cc3d.connected_components(
+            zeros_padded.detach().squeeze().cpu().numpy(), connectivity=4
+        ).reshape(zeros_padded.shape)
+        zeros_padded[
+            torch.tensor(zeros_padded_cc != zeros_padded_cc.ravel()[0], device=zeros_padded.device)
+        ] = False  # keep masking resin, restore most soma
+
+        zeros_warped = (
+            torch.nn.functional.pad(field, (1, 1, 1, 1), mode="replicate")
+            .from_pixels()
+            .sample((~zeros_padded).float(), padding_mode="border")
+            <= 0.1
+        )
+        zeros_warped = torch.nn.functional.pad(zeros_warped, (-1, -1, -1, -1), value=True)
+
+        img_warped[zeros_warped] = self.zero_value
+        return img_warped, zeros_warped
+
+    def _down_zeros_mask(self, zeros_mask, count=1):
+        scale_factor = 0.5**count
+        return (
+            torch.nn.functional.interpolate(
+                zeros_mask.float(), scale_factor=scale_factor, mode="bilinear"
+            )
+            > 0.99
+        )  # 0.01
+
+    def compute_metroem_loss(self, batch: dict, mode: str, log_row: bool, sample_name: str = ""):
+        src = batch["images"]["src"]
+        tgt = batch["images"]["tgt"]
+
+        if (
+            (src == self.zero_value) + (tgt == self.zero_value)
+        ).bool().sum() / src.numel() > self.empty_tissue_threshold:
+            return None
+
+        seed_field = batch["field"].field_()
+        f_warp_large = seed_field * self.max_displacement_px
+        f_warp_small = (
+            seed_field
+            * self.field_magn_thr
+            * self.ds_factor
+            / torch.quantile(seed_field.abs().max(1)[0], 0.5)
+        )
+
+        f_aff = (
+            tensor_ops.transform.get_affine_field(
+                size=src.shape[-1],
+                rot_deg=self.equivar_rot_deg_distr(),
+                scale=self.equivar_scale_distr(),
+                shear_x_deg=self.equivar_shear_deg_distr(),
+                shear_y_deg=self.equivar_shear_deg_distr(),
+                trans_x_px=self.equivar_trans_px_distr(),
+                trans_y_px=self.equivar_trans_px_distr(),
+            )
+            .pixels()
+            .to(seed_field.device)
+        )
+        f1_trans = f_aff.from_pixels()(f_warp_large.from_pixels()).pixels()
+        f2_trans = f_warp_small.from_pixels()(f1_trans.from_pixels()).pixels()
+
+        magn_field = f_warp_small
+
+        src_f1, src_zeros_f1 = self._get_warped(src, f1_trans)
+        src_f2, src_zeros_f2 = self._get_warped(src, f2_trans)
+        tgt_f1, tgt_zeros_f1 = self._get_warped(tgt, f1_trans)
+
+        src_zeros_f1 = self._down_zeros_mask(src_zeros_f1, count=int(log2(self.ds_factor)))
+        src_zeros_f2 = self._down_zeros_mask(src_zeros_f2, count=int(log2(self.ds_factor)))
+        tgt_zeros_f1 = self._down_zeros_mask(tgt_zeros_f1, count=int(log2(self.ds_factor)))
+
+        src_enc = src
+        src_f1_enc = src_f1
+        src_enc = self.model(src_enc)
+        src_f1_enc = self.model(src_f1_enc)
+
+        f_pad = self.ds_factor
+        src_enc_f1 = torch.nn.functional.pad(
+            src_enc, (1, 1, 1, 1), value=0.0
+        )  # TanH! - fill with output zero value
+        src_enc_f1 = (
+            torch.nn.functional.pad(f1_trans, (f_pad, f_pad, f_pad, f_pad), mode="replicate")  # type: ignore
+            .from_pixels()
+            .down(int(log2(self.ds_factor)))
+            .sample(src_enc_f1, padding_mode="border")
+        )
+        src_enc_f1 = torch.nn.functional.pad(src_enc_f1, (-1, -1, -1, -1), value=0.0)
+
+        equi_diff = (src_enc_f1 - src_f1_enc).abs()
+        # equi_loss = equi_diff[src_zeros_f1 == 0].sum()
+        equi_loss = equi_diff.sum()
+        equi_diff_map = equi_diff.clone()
+        # equi_diff_map[src_zeros_f1] = 0
+
+        src_f2_enc = src_f2
+        tgt_f1_enc = tgt_f1
+        src_f2_enc = self.model(src_f2_enc)
+        tgt_f1_enc = self.model(tgt_f1_enc)
+
+        pre_diff = (src_f1_enc - tgt_f1_enc).abs()
+
+        pre_tissue_mask = tensor_ops.mask.coarsen(tgt_zeros_f1 + src_zeros_f1, width=2) == 0
+        pre_loss = pre_diff[..., pre_tissue_mask].sum()
+        pre_diff_masked = pre_diff.clone()
+        pre_diff_masked[..., pre_tissue_mask == 0] = 0
+
+        post_tissue_mask = tensor_ops.mask.coarsen(tgt_zeros_f1 + src_zeros_f2, width=2) == 0
+
+        post_magn_mask = (
+            (magn_field.from_pixels().down(int(log2(self.ds_factor))).pixels().abs().max(1)[0])
+            > self.field_magn_thr
+        ).tensor_()
+
+        post_diff_map = (src_f2_enc - tgt_f1_enc).abs()
+        post_mask = post_magn_mask * post_tissue_mask
+        if post_mask.sum() < (256 // (2 * self.ds_factor)):
+            return None
+
+        post_loss = post_diff_map[..., post_mask].sum()
+
+        post_diff_masked = post_diff_map.clone()
+        post_diff_masked[..., post_mask == 0] = 0
+
+        if mode == "train":
+            self._training_step += 1
+
+        post_weight_ratio = min(
+            1,
+            max(0, self._training_step - self.post_weight_start_step)
+            / max(1, self.post_weight_end_step - self.post_weight_start_step),
+        )
+        post_weight = (
+            post_weight_ratio * self.post_weight_end_val
+            + (1.0 - post_weight_ratio) * self.post_weight_start_val
+        )
+
+        loss = pre_loss - post_loss * post_weight + equi_loss * self.equivar_weight
+        self.log(f"param/post_weight", post_weight, on_step=True, on_epoch=True)
+        self.log(f"loss/{mode}_apply", loss, on_step=True, on_epoch=True)
+        self.log(f"loss/{mode}_apply_pre", pre_loss, on_step=True, on_epoch=True)
+        self.log(f"loss/{mode}_apply_post", post_loss, on_step=True, on_epoch=True)
+        self.log(f"loss/{mode}_apply_equi", equi_loss, on_step=True, on_epoch=True)
+        if log_row:
+            self.log_results(
+                mode,
+                sample_name,
+                src=src,
+                src_enc=src_enc,
+                src_f1=src_f1,
+                src_enc_f1=src_enc_f1,
+                src_f1_enc=src_f1_enc,
+                src_f2_enc=src_f2_enc,
+                tgt_f1=tgt_f1,
+                tgt_f1_enc=tgt_f1_enc,
+                field=seed_field.tensor_(),
+                equi_diff_map=equi_diff_map,
+                post_diff_masked=post_diff_masked,
+                pre_diff_masked=pre_diff_masked,
+            )
+        return loss
+
+    def validation_step(self, batch, batch_idx):  # pylint: disable=arguments-differ
+        log_row = batch_idx % self.val_log_row_interval == 0
+        sample_name = f"{batch_idx // self.val_log_row_interval}"
+
+        loss = self.compute_metroem_loss(
+            batch=batch, mode="val", log_row=log_row, sample_name=sample_name
+        )
+        return loss


### PR DESCRIPTION
First commit contains the new specs used for training/inference for what we have right now, so that I don't lose them. Also adds the coarsener regime (training+inference)

Second, separate commit updates the BaseEncoder regime - no fundamental change, just slightly different handling of boundary regions. But wanted to check with you first If that is problematic,