### PR TITLE
Register public torch methods

### DIFF
--- a/zetta_utils/convnet/architecture/primitives.py
+++ b/zetta_utils/convnet/architecture/primitives.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence as AbcSequence
 from functools import partial
+from types import BuiltinMethodType
 from typing import Any, Callable, List, Literal, Sequence
 
 import torch
@@ -19,6 +20,12 @@ NN_MANUAL = [
 for k in dir(torch.nn):
     if k not in NN_MANUAL and k[0].isupper():
         builder.register(f"torch.nn.{k}")(getattr(torch.nn, k))
+
+for module in [torch, torch.nn.functional, torch.linalg, torch.fft]:
+    for k in dir(module):
+        attr = getattr(module, k)
+        if isinstance(attr, BuiltinMethodType) and not k.startswith("_"):
+            builder.register(f"{module.__name__}.{k}")(attr)
 
 
 @builder.register("torch.nn.Sequential")

--- a/zetta_utils/layer/layer_base.py
+++ b/zetta_utils/layer/layer_base.py
@@ -47,7 +47,7 @@ class Layer(Generic[BackendIndexT, BackendDataT]):
             if isinstance(e, JointIndexDataProcessor):
                 data_proced = e.process_data(data=data_proced, mode="read")
             else:
-                data_proced = e(data=data_proced)
+                data_proced = e(data_proced)
 
         return data_proced
 
@@ -72,7 +72,7 @@ class Layer(Generic[BackendIndexT, BackendDataT]):
             if isinstance(e, JointIndexDataProcessor):
                 data_proced = e.process_data(data_proced, mode="write")
             else:
-                data_proced = e(data=data_proced)
+                data_proced = e(data_proced)
 
         self.backend.write(idx=idx_proced, data=data_proced)
 

--- a/zetta_utils/layer/layer_base.py
+++ b/zetta_utils/layer/layer_base.py
@@ -65,12 +65,12 @@ class Layer(Generic[BackendIndexT, BackendDataT]):
 
         for e in self.write_procs:
             if isinstance(e, JointIndexDataProcessor):
-                idx_proced = e.process_index(idx_proced, mode="write")
+                idx_proced = e.process_index(idx=idx_proced, mode="write")
 
         data_proced = data
         for e in self.write_procs:
             if isinstance(e, JointIndexDataProcessor):
-                data_proced = e.process_data(data_proced, mode="write")
+                data_proced = e.process_data(data=data_proced, mode="write")
             else:
                 data_proced = e(data_proced)
 

--- a/zetta_utils/layer/tools_base.py
+++ b/zetta_utils/layer/tools_base.py
@@ -10,12 +10,12 @@ T = TypeVar("T")
 
 
 class DataProcessor(Protocol[T]):
-    def __call__(self, data: T) -> T:
+    def __call__(self, __data: T) -> T:
         ...
 
 
 class IndexProcessor(Protocol[T]):
-    def __call__(self, idx: T) -> T:
+    def __call__(self, __idx: T) -> T:
         ...
 
 


### PR DESCRIPTION
Provides access to all the builtins in `torch`, `torch.nn.functional`, `torch.linalg` and `torch.fft`.

It will not work with all function signatures (the ones that don't expect the tensor as first input), but I hope the easy accessibility of a wide range of operations may outweigh the few edge cases