### PR TITLE
feat: TransientError handling for mazepa executions

### DIFF
--- a/zetta_utils/mazepa/__init__.py
+++ b/zetta_utils/mazepa/__init__.py
@@ -4,7 +4,13 @@ from . import exceptions
 
 from .task_outcome import TaskOutcome, TaskStatus
 
-from .tasks import Task, TaskableOperation, taskable_operation, taskable_operation_cls
+from .tasks import (
+    Task,
+    TaskableOperation,
+    taskable_operation,
+    taskable_operation_cls,
+    TransientErrorCondition,
+)
 from .flows import (
     Flow,
     FlowFnReturnType,

--- a/zetta_utils/mazepa/remote_execution_queues/sqs_queue.py
+++ b/zetta_utils/mazepa/remote_execution_queues/sqs_queue.py
@@ -139,10 +139,12 @@ class SQSExecutionQueue:
             max_time_sec=self.pull_wait_sec,
             visibility_timeout=self.pull_lease_sec,
         )
+
         for msg in msgs:
             # Deserialize task object
             tq_task = taskqueue.totask(json.loads(msg.body))
             task = serialization.deserialize(tq_task.task_ser)
+            task.curr_retry = msg.approx_receive_count - 1
 
             # Specify completion behavior through callbacks
             task.completion_callbacks.append(

--- a/zetta_utils/mazepa/task_outcome.py
+++ b/zetta_utils/mazepa/task_outcome.py
@@ -13,6 +13,7 @@ class TaskStatus(Enum):
     RUNNING = auto()
     SUCCEEDED = auto()
     FAILED = auto()
+    TRANSIENT_ERROR = auto()
 
 
 R_co = TypeVar("R_co", covariant=True)


### PR DESCRIPTION
Lets the user specify which Exceptions/Text indicate a transient error and should be retried, rather than aborting execution.

These specification are passed to `@taskable_operation`/`@taskable_operation_cls` decorators to allow fine grained control over which tasks should be retried in which conditions. Some reasonable default set of transient exceptions is provided.

Transient errors will be ignored only if the task has been attempted less than a certain number of times, and will error out aborting the execution after that. This is because some errors (aka NVIDIA driver) can be both transient or non-transient.