### PR TITLE
fix(mazepa): Another Runtime error caused by expired grace period

### DIFF
--- a/zetta_utils/mazepa/tasks.py
+++ b/zetta_utils/mazepa/tasks.py
@@ -56,7 +56,14 @@ class TransientErrorCondition:
 
 DEFAULT_TRANSIENT_ERROR_CONDITIONS: Final = (
     TransientErrorCondition(
-        exception_type=RuntimeError, text_signature="Found no NVIDIA driver on your system"
+        # If running on GPU spot instance: Graceful shutdown failed
+        exception_type=RuntimeError,
+        text_signature="Found no NVIDIA driver on your system",
+    ),
+    TransientErrorCondition(
+        # If running on GPU spot instance: Graceful shutdown failed
+        exception_type=RuntimeError,
+        text_signature="Attempting to deserialize object on a CUDA device",
     ),
 )
 


### PR DESCRIPTION
Still considering this a temporary fix. Both exceptions are legitimate and should not be retried when they occur on an instance without GPU or incorrect CUDA setup.