### PR TITLE
Fixes regarding duplicate tasks

### DIFF
--- a/zetta_utils/mazepa/execution_state.py
+++ b/zetta_utils/mazepa/execution_state.py
@@ -174,8 +174,10 @@ class InMemoryExecutionState(ExecutionState):  # pylint: disable=too-many-instan
         self.leftover_ready_tasks = result[max_batch_len:]
 
         for e in result_final:
-            self.ongoing_tasks_dict[e.id_] = e
-            self.submitted_counts[e.operation_name] += 1
+            if e.id_ not in self.ongoing_tasks_dict:
+                # Duplicate tasks don't count
+                self.ongoing_tasks_dict[e.id_] = e
+                self.submitted_counts[e.operation_name] += 1
 
         return result_final
 

--- a/zetta_utils/mazepa_layer_processing/common/interpolate_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/interpolate_flow.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import functools
 from typing import Optional, Sequence, Union
 
 import torch
 
 from zetta_utils import builder, mazepa, tensor_ops
+from zetta_utils.common import ComparablePartial
 from zetta_utils.geometry import BBox3D, Vec3D
 from zetta_utils.layer.volumetric import (
     VolumetricIndex,
@@ -40,7 +40,7 @@ def make_interpolate_operation(
     mask_value_thr: float = 0,
 ):
     op = VolumetricCallableOperation(
-        fn=functools.partial(
+        fn=ComparablePartial(
             _interpolate,
             mode=mode,
             scale_factor=1 / Vec3D(*res_change_mult),


### PR DESCRIPTION
Overlapping bounding boxes led to duplicate tasks from different parent flows.
* duplicate tasks now correctly track and update all associated parent flows upon completion
* duplicate tasks are now excluded from the progress report tally / reported counts should now line up with the dryrun results

Unrelated: `interpolate_flow` tasks would not receive a consistent hash across runs due to a `functools.partial` memory adress in the `TaskableOperation.__repr__()`
* switched to `ComparablePartial` for now, but something similar could easily happen in other places, I imagine.