### PR TITLE
feat: integration tests with Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 **/*.npy filter=lfs diff=lfs merge=lfs -text
 **/*.gz filter=lfs diff=lfs merge=lfs -text
 *.pkl filter=lfs diff=lfs merge=lfs -text
+tests/integration/assets/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -63,6 +63,8 @@ jobs:
         with:
           files: /home/runner/work/zetta_utils/zetta_utils/coverage.xml
 
+          
+
   pylint-isort:
     strategy:
       matrix:

--- a/.github/workflows/testing_integration.yaml
+++ b/.github/workflows/testing_integration.yaml
@@ -1,0 +1,60 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+env:
+  WANDB_MODE: offline
+  SETUPTOOLS_ENABLE_FEATURES: legacy-editable
+
+jobs:
+  pytest:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.9"
+          - "3.10"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: 'true'
+          submodules: 'recursive'
+          ssh-key: ${{ secrets.git_ssh_key  }}
+      - name: Get changed files
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          list-files: shell
+          base: 'main'
+          filters: |
+            py_modified:
+              - added|modified: "./**/*.py"
+      - name: Setup Python
+        if: ${{ steps.filter.outputs.py_modified == 'true' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
+      - name: Setup Go
+        if: ${{ steps.filter.outputs.py_modified == 'true' }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.4'
+      - name: Install Python dependencies
+        if: ${{ steps.filter.outputs.py_modified == 'true' }}
+        run: pip install -e '.[modules, test]'
+      - name: Install CUE
+        if: ${{ steps.filter.outputs.py_modified == 'true' }}
+        run: go install cuelang.org/go/cmd/cue@latest
+      - name: Run pytest
+        if: ${{ steps.filter.outputs.py_modified == 'true' }}
+        run: coverage run -m pytest --run-integration .
+      - name: Send coverage repot to codecov
+        uses: codecov/codecov-action@v3
+        if: ${{ steps.filter.outputs.py_modified == 'true' }}
+        with:
+          files: /home/runner/work/zetta_utils/zetta_utils/coverage_integration.xml

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ coverage.xml
 
 # Temporary precomputed volumes and infofiles
 tests/unit/assets/infos/scratch/
+tests/integration/assets/outputs/
+tests/integration/assets/temp/
 
 # Translations
 *.mo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_addoption(parser):
+    parser.addoption("--run-integration", default=False, help="Run integration tests")

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef02c821275ca8ad1cfa3fdf94eeabb4bc763864a90bd4878355933e48121be
+size 25858

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4263408f43a2403d29a4f4fa1e44af4e2767ca58cd1dcebd8b46398b1503900f
+size 25860

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c3aa102d9de9ac6ff9dceb4994d894ebb8c2feb1bd52e8502a232cc80e26371
+size 26153

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8daa585d08f873414ca5f6fd0c0349443d93e691e441faa800242e2c79d1568
+size 25904

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ddacede4167df2d8679421e498e969b30ce02ce88e91b17a6b2520c7a84481
+size 25988

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83b4bcb69c92392b0071773f6555e8ef8272f719e4c2baa6e46a3481a2cd686
+size 26070

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31f15d9cc8574b281ddcf156670ee55361c163dbb516ddc28b162bb08e3b3e30
+size 26395

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe8cd9087d3e7235a07af5ca3186b145189de81acdbdf810350d4a4190e23e0
+size 26370

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb3310c5c5da6ecfa42a22debb8039c8849a2c80bb414aa7b5189c36e729a5c
+size 26811

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069d4afe1a6fe99b802d3c8a1ee4a6745ccacd9731196204cc717b3a0bc78dd7
+size 26589

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f4e125284365b9d05c9ff640997b12adad816a18422a0d601b0261f7af2b81
+size 26998

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f79ed1350416a35516fff1ccc86f316a8662e3707c93460c087232402ac2bc5
+size 27568

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6228419087915b48c6ec2edabb7ff12e1dfa1f4d9912b613f954fbb0a95bf7f8
+size 27362

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2eca20b22aeaa6a225fd7fdfd8dacd9916f6d577ba464d1bc7f5c5ca2dc4e5e
+size 27398

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f891f1ba02d06ed11d779f29cb57c331d9751c3e815714f49eabbd8e9fb66081
+size 27256

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8955a89fd8e7d632ced8202f6b01aea2261f16a3ebb141168f6f5718990e3b30
+size 27407

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17c415fedfed5a93d085c23259c2ca6c5123cb58b569832c7c6bf7775d6f03ac
+size 27638

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f2def0d4733cf74d8fc5d27bbf2de51882850a9f8e47c5ad7d0636e6d8b619
+size 27620

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20abe76d7281346f84498261fb42be7b3eabe00db3b96eb08780e2256f45a7c
+size 27960

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b233f630c1ec14abd0c90e5b20c6324d8c3724fc58a1abb049377700a53272c6
+size 28098

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c090c90a6221269ffeb96ed40fa94bba1e39fd803fa905799be625132853f4af
+size 27230

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3deacf1948ce4631bdbb8592bfd281727b979312125beb0be39640bedc262d0
+size 27056

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8754ec3990cef6b614278f4d0273a43dff3b165bbec18aadfa4115d2cda1afd6
+size 27603

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3313f697b479fa8c8395266f74ab98da17e15f1737fa380581d13266e3d85a
+size 27776

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9484ed7d372882b2d2c6880ec6060877a42b70674335aca599ac3a36e719d67
+size 28414

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156377bf37e671f568897a260087160907f0016c72d1b4556842e3e227662b3e
+size 28083

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e68d8986ba9b4c26947a681fc109cda26afc270503c46bcc3cd900f17c58b8b
+size 27831

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05d0642192f4d3433b2e76a565b4142eb7edc0534353279b4a121dc54651e00
+size 28049

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97e43378e18bfff9f8f9c17c1fe50de7c03ee040e9276949222f1be4e4ca33de
+size 28353

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f717226631d6f3a6b7730b91c27261e3f16806897a68c09eb951a13db2f3dc62
+size 28147

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0bb628ed914af660b0be30f089905147f314d80b218c9b110b73393a97fc9c2
+size 28705

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86eea13c286112124e6610ff1fb50e98a4439c5af9c291261bbb364c7599321
+size 28790

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0b8d5083c6b8968b98e92b0d896e8e32d556804caeed538ce13aced4e92c66a
+size 28501

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d19a6e4332ee529961ece65235e15b6d01eb3f5a9109d561f5bcade16bd8c9
+size 29049

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d7887a28dafa2cd7d05cac1cb62928f906a37c1cb644ae56bd1fc01d86f1370
+size 29044

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b58462a562797a07a8be1d9dd87b3de33778095cb4839109cbefc75b38bddb5c
+size 28920

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fda956ea5b3bb6fc4fcf9e01e6c225160c4b258ff350a0f4b4a0368a5ee6e8d
+size 29074

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eeb8bddc7c96c49ddb21b52813bcf8f0aef32d1058a92248338d345f70770d
+size 29196

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c4306824ad32db80c6188b131481ea6f783f6cefa16a09c826ebbadfd82e18
+size 29041

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:628839a2b3fca16ba6c08e40bbf96c23e5388b0f4690c1cf2ef6d8a7dba3a4ce
+size 29083

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bdbbd62826f3f2ea736ce45070f33846ef0f34bd98ebdca2ee320878c37d95
+size 29680

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81386374fed6c7a37c9f499347bd48564349466b126273bd78afcd7e401d0cb
+size 30167

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b3107c1fe7042b121a2cfdb559c0c0966cd236e4b0aa4df500a1cb1163f2f1
+size 29468

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d9c56f30a1ce02ea79df74c4599a3cc9be003e99b1d832ea14a555443182ea
+size 29160

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e44f722d266064bc929f44a90553bee890abc0da756f9eb31f3ce45d11f5d73
+size 29737

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c8405074db04d80f9769e3af51859d6f29daad94d191a7aeb6214ead5f7ee56
+size 29723

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f0c40674845bc8124b8b1a93a357128254fe292cd859f0a6f3150cf982af20
+size 30060

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0aab618b9e3d37546b3c07635088631e18d52ad92ebc5009a6d3f58ba231405
+size 30395

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4886826785e012315006d26bf7b6aecbf51e7f61891889659df6413a34b5e30
+size 30349

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6cdb7a8780f63fd100dea52ca5afd61ac0010356ba3923b8ce8021c49444590
+size 30548

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/info
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e72430dbdb37f95c225f052c6c1cdd76c45f4fd36d40784f44af1945e318a6d
+size 1508

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8abda4dcb88e9f33eb7582fa146e00c63d761ab66ada27b1daf51d80acd6210
+size 44162

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90f724f5e729d02668b14eac6802af6f19a85d8f7072a9400c0d29ceb4c91de
+size 44257

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b8398bd30ac9f440b64777c7b6962b3c13c9af143ac6da7cdde15c747d3a84
+size 44497

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b780953eb3ab80a9f94288890de3f230d2f820d18a76845b346090bdc481c7
+size 43740

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48798b0f808dc5e0fc2ad074c13109820ccf50fcf79dbc1140626fef95917fc
+size 44282

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:329da58d5dedc7f78b7e0a8d0c692c42a9c0a9d7702e582582e293833143ffe7
+size 44086

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed74e85b4e4125dd1b9718de57a436e27a74cd1b707a56614c2e14c904bbfa6e
+size 44735

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7cc0b55aa845c6bf1b0286f67a931774e11904cb79ee82c4c423fe92c82353e
+size 44900

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37bc95bbbe71ed96d1b1df5850cf46b611d6d19e18cb293ef245e88b73c7b86
+size 45770

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5302b408b6f32fabb84e40ee4bfd99c17ac4465949278d4b34ed495e50f29099
+size 45033

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1f097e746620ab7575daa91e87914aa22f418ad6c647bb8d84dd26d17690977
+size 45874

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfcaa309b4268ddca089a4e529924d63d7baad03ecbbb6f6cfd274079017607f
+size 46720

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b411951f3bd04ded9a1a5bfe071a97124c62995d918b9f6b940933d550c6b6cf
+size 46149

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940e515678906e9d3bcdd463266187deef29d2eb9f14bcade02ff6dc78b80b0a
+size 46470

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9757c0c1c95a1c1d433a82f4986461b26af97af38af9d6b90adebcf1cf82c992
+size 46184

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f3417cc2ae68c72db5f65849dc1a66dace941c55ca2f375d4f1ed4582f2423
+size 46159

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6155833d77251180ebeff054b6b7f5a62565f2dd8ec23d006dbeb34ddd48f45
+size 46791

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82361878d5054684d2545534af585a45aacad7f446e934de00195621a788818
+size 46698

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe0f88e167753bd1c01cfe41a9d90bbf36d5f6938f167c7b6d028a75b2d0ee98
+size 47250

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63dc0711bb9421bb9978d0e9f4d2d1b6ad70ec7e996b3749dc7617689cb42098
+size 47634

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94248471f7959790f2734c91ae13bbf8b57e94b5a92cfe34a0d394f812698ebf
+size 46349

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50b9cc51b13cd53d019a8396c37afdfbd44fa247a66b979452fe3e3a2bd35e1
+size 46023

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8da2278c21d19d6a9e5c8fef87f0ef60407a274b27a0acda86a0dc342fbb718
+size 46764

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2033a90efbd331209e3e374f7b6f27499b3ac0d882042b751648d8f6fa4ee775
+size 46939

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ae8e30c439f180b81ea9e7a8fcf025af63d73b37f56cd31ac1a7ee4291f036
+size 48173

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f4eebdc04fc52a3c917f94745e23227326ada8ef7fb26e07ab7bb65f3b35f21
+size 47561

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb897e18b11f1c9591d17e394240d0bcf7ae004d46689b6b549888d1cd122027
+size 47266

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7870863dc873f84f0d2832d2f9771bbc4ce1bf365343755506834111d8dc36e
+size 47517

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:342a74ce066694bffe99092973e5e3c8d70d93f4f8a6c9b53aa54ad3b2efdfa6
+size 47920

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161a542b26abec70c2a2395d4d0eae8684a3f5885aef422a01057a5fb2f56d4d
+size 47635

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d007007ddf81f80748c45bc81122f3bc327845ea1ca7d308fba5dac50ef42db6
+size 48306

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c621cf7b26ed3120b2df467555c261976b4b71be653b233a419bc5f29bf92a
+size 47762

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48e030152c213f1cb9c41a86c174756884f548799b34a22386fb1ed1bfe4c0fc
+size 47993

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b11587ef51b451919d01f772d0d02a7476b31832e16fe712ae06ddd90092ac0
+size 48749

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb924d47353cf3201a456ee21391f544034f385bc20ac278e1174a533c9de45
+size 48849

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d7c272aee4ef4387ec564571b46157a7e9db5b74b00202390f572b53ee0ce10
+size 48724

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6464b8b0074daf76593fb64452b27fbcb60988a76bf72908dbb2e488b907844e
+size 48809

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e616a25547b1eb11bcfdffbfd68cc0e0da93e94b0b03b0f8f50fd13ba033f922
+size 49423

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7bce1b205803bd9dfd29a54b373433f011d8dff09c1dd1150907d00cf741f8
+size 49057

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856230377b662344eb7b0374b7032f90469d18b8c3b179b25108c0c1cd59e7ef
+size 48971

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab7cfcbf194536149ff3fa03f29a4683b85a69b1530a268a5c2445e0cfb9c80
+size 49939

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0eeb867ae88da5485882c4856f61d806d258fed749ad762a082153a9d70ae3e
+size 50722

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0014cc77aec3a7ba64be977d14395c62b3bf9f99a3cdac50061e2c8d7c4b7b03
+size 49462

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43146575d9e7af5873b107c70f78bbabe87c1e6e223df5e2c054bebf98e55352
+size 48594

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d1b0b3f758e98d165eb36ec311755db89f7f6bfab6a1330b0f05e2adff635c
+size 50037

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e6bd67324c7e52383bfe8126f1e06b0f81ec24fd2a163d001386118903f4aa
+size 50139

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4fa5fbeca17aa83183b1094b561237bda3203722f01ad7089c0be8edba2e3f9
+size 50243

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0663ec02c0b4e86ea11b7c998f65435f59b0fd4b44ccf3e7004363da4bdf57f8
+size 50849

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5263f682cb4a3de93f138155dc1f70595e2acad560b189234c8f8cce8666ba
+size 51054

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d666c294ae94aac9fe7545c52590151e53f979e85f50f4aac189478e694b5f4
+size 51116

--- a/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/info
+++ b/tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29b43427213957b4f07707bd67fcf18e4c29c7f9523a88c615bd529e23624cfe
+size 1510

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8abda4dcb88e9f33eb7582fa146e00c63d761ab66ada27b1daf51d80acd6210
+size 44162

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90f724f5e729d02668b14eac6802af6f19a85d8f7072a9400c0d29ceb4c91de
+size 44257

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b8398bd30ac9f440b64777c7b6962b3c13c9af143ac6da7cdde15c747d3a84
+size 44497

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b780953eb3ab80a9f94288890de3f230d2f820d18a76845b346090bdc481c7
+size 43740

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48798b0f808dc5e0fc2ad074c13109820ccf50fcf79dbc1140626fef95917fc
+size 44282

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:329da58d5dedc7f78b7e0a8d0c692c42a9c0a9d7702e582582e293833143ffe7
+size 44086

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed74e85b4e4125dd1b9718de57a436e27a74cd1b707a56614c2e14c904bbfa6e
+size 44735

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7cc0b55aa845c6bf1b0286f67a931774e11904cb79ee82c4c423fe92c82353e
+size 44900

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37bc95bbbe71ed96d1b1df5850cf46b611d6d19e18cb293ef245e88b73c7b86
+size 45770

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5302b408b6f32fabb84e40ee4bfd99c17ac4465949278d4b34ed495e50f29099
+size 45033

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1f097e746620ab7575daa91e87914aa22f418ad6c647bb8d84dd26d17690977
+size 45874

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfcaa309b4268ddca089a4e529924d63d7baad03ecbbb6f6cfd274079017607f
+size 46720

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b411951f3bd04ded9a1a5bfe071a97124c62995d918b9f6b940933d550c6b6cf
+size 46149

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940e515678906e9d3bcdd463266187deef29d2eb9f14bcade02ff6dc78b80b0a
+size 46470

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9757c0c1c95a1c1d433a82f4986461b26af97af38af9d6b90adebcf1cf82c992
+size 46184

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f3417cc2ae68c72db5f65849dc1a66dace941c55ca2f375d4f1ed4582f2423
+size 46159

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6155833d77251180ebeff054b6b7f5a62565f2dd8ec23d006dbeb34ddd48f45
+size 46791

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82361878d5054684d2545534af585a45aacad7f446e934de00195621a788818
+size 46698

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe0f88e167753bd1c01cfe41a9d90bbf36d5f6938f167c7b6d028a75b2d0ee98
+size 47250

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63dc0711bb9421bb9978d0e9f4d2d1b6ad70ec7e996b3749dc7617689cb42098
+size 47634

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94248471f7959790f2734c91ae13bbf8b57e94b5a92cfe34a0d394f812698ebf
+size 46349

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50b9cc51b13cd53d019a8396c37afdfbd44fa247a66b979452fe3e3a2bd35e1
+size 46023

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8da2278c21d19d6a9e5c8fef87f0ef60407a274b27a0acda86a0dc342fbb718
+size 46764

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2033a90efbd331209e3e374f7b6f27499b3ac0d882042b751648d8f6fa4ee775
+size 46939

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ae8e30c439f180b81ea9e7a8fcf025af63d73b37f56cd31ac1a7ee4291f036
+size 48173

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f4eebdc04fc52a3c917f94745e23227326ada8ef7fb26e07ab7bb65f3b35f21
+size 47561

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb897e18b11f1c9591d17e394240d0bcf7ae004d46689b6b549888d1cd122027
+size 47266

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7870863dc873f84f0d2832d2f9771bbc4ce1bf365343755506834111d8dc36e
+size 47517

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:342a74ce066694bffe99092973e5e3c8d70d93f4f8a6c9b53aa54ad3b2efdfa6
+size 47920

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161a542b26abec70c2a2395d4d0eae8684a3f5885aef422a01057a5fb2f56d4d
+size 47635

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d007007ddf81f80748c45bc81122f3bc327845ea1ca7d308fba5dac50ef42db6
+size 48306

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c621cf7b26ed3120b2df467555c261976b4b71be653b233a419bc5f29bf92a
+size 47762

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48e030152c213f1cb9c41a86c174756884f548799b34a22386fb1ed1bfe4c0fc
+size 47993

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b11587ef51b451919d01f772d0d02a7476b31832e16fe712ae06ddd90092ac0
+size 48749

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb924d47353cf3201a456ee21391f544034f385bc20ac278e1174a533c9de45
+size 48849

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d7c272aee4ef4387ec564571b46157a7e9db5b74b00202390f572b53ee0ce10
+size 48724

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6464b8b0074daf76593fb64452b27fbcb60988a76bf72908dbb2e488b907844e
+size 48809

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e616a25547b1eb11bcfdffbfd68cc0e0da93e94b0b03b0f8f50fd13ba033f922
+size 49423

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7bce1b205803bd9dfd29a54b373433f011d8dff09c1dd1150907d00cf741f8
+size 49057

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856230377b662344eb7b0374b7032f90469d18b8c3b179b25108c0c1cd59e7ef
+size 48971

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab7cfcbf194536149ff3fa03f29a4683b85a69b1530a268a5c2445e0cfb9c80
+size 49939

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0eeb867ae88da5485882c4856f61d806d258fed749ad762a082153a9d70ae3e
+size 50722

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0014cc77aec3a7ba64be977d14395c62b3bf9f99a3cdac50061e2c8d7c4b7b03
+size 49462

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43146575d9e7af5873b107c70f78bbabe87c1e6e223df5e2c054bebf98e55352
+size 48594

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d1b0b3f758e98d165eb36ec311755db89f7f6bfab6a1330b0f05e2adff635c
+size 50037

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e6bd67324c7e52383bfe8126f1e06b0f81ec24fd2a163d001386118903f4aa
+size 50139

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4fa5fbeca17aa83183b1094b561237bda3203722f01ad7089c0be8edba2e3f9
+size 50243

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0663ec02c0b4e86ea11b7c998f65435f59b0fd4b44ccf3e7004363da4bdf57f8
+size 50849

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5263f682cb4a3de93f138155dc1f70595e2acad560b189234c8f8cce8666ba
+size 51054

--- a/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d666c294ae94aac9fe7545c52590151e53f979e85f50f4aac189478e694b5f4
+size 51116

--- a/tests/integration/assets/outputs_ref/test_float32_copy/info
+++ b/tests/integration/assets/outputs_ref/test_float32_copy/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60478db6a50e848b9bfa56e1ca7b634a4d5bb44e613674a96c524be5b5479fbb
+size 1509

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8abda4dcb88e9f33eb7582fa146e00c63d761ab66ada27b1daf51d80acd6210
+size 44162

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90f724f5e729d02668b14eac6802af6f19a85d8f7072a9400c0d29ceb4c91de
+size 44257

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b8398bd30ac9f440b64777c7b6962b3c13c9af143ac6da7cdde15c747d3a84
+size 44497

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b780953eb3ab80a9f94288890de3f230d2f820d18a76845b346090bdc481c7
+size 43740

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48798b0f808dc5e0fc2ad074c13109820ccf50fcf79dbc1140626fef95917fc
+size 44282

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:329da58d5dedc7f78b7e0a8d0c692c42a9c0a9d7702e582582e293833143ffe7
+size 44086

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed74e85b4e4125dd1b9718de57a436e27a74cd1b707a56614c2e14c904bbfa6e
+size 44735

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7cc0b55aa845c6bf1b0286f67a931774e11904cb79ee82c4c423fe92c82353e
+size 44900

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37bc95bbbe71ed96d1b1df5850cf46b611d6d19e18cb293ef245e88b73c7b86
+size 45770

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5302b408b6f32fabb84e40ee4bfd99c17ac4465949278d4b34ed495e50f29099
+size 45033

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1f097e746620ab7575daa91e87914aa22f418ad6c647bb8d84dd26d17690977
+size 45874

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfcaa309b4268ddca089a4e529924d63d7baad03ecbbb6f6cfd274079017607f
+size 46720

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b411951f3bd04ded9a1a5bfe071a97124c62995d918b9f6b940933d550c6b6cf
+size 46149

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940e515678906e9d3bcdd463266187deef29d2eb9f14bcade02ff6dc78b80b0a
+size 46470

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9757c0c1c95a1c1d433a82f4986461b26af97af38af9d6b90adebcf1cf82c992
+size 46184

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f3417cc2ae68c72db5f65849dc1a66dace941c55ca2f375d4f1ed4582f2423
+size 46159

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6155833d77251180ebeff054b6b7f5a62565f2dd8ec23d006dbeb34ddd48f45
+size 46791

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82361878d5054684d2545534af585a45aacad7f446e934de00195621a788818
+size 46698

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe0f88e167753bd1c01cfe41a9d90bbf36d5f6938f167c7b6d028a75b2d0ee98
+size 47250

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63dc0711bb9421bb9978d0e9f4d2d1b6ad70ec7e996b3749dc7617689cb42098
+size 47634

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94248471f7959790f2734c91ae13bbf8b57e94b5a92cfe34a0d394f812698ebf
+size 46349

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50b9cc51b13cd53d019a8396c37afdfbd44fa247a66b979452fe3e3a2bd35e1
+size 46023

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8da2278c21d19d6a9e5c8fef87f0ef60407a274b27a0acda86a0dc342fbb718
+size 46764

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2033a90efbd331209e3e374f7b6f27499b3ac0d882042b751648d8f6fa4ee775
+size 46939

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ae8e30c439f180b81ea9e7a8fcf025af63d73b37f56cd31ac1a7ee4291f036
+size 48173

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f4eebdc04fc52a3c917f94745e23227326ada8ef7fb26e07ab7bb65f3b35f21
+size 47561

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb897e18b11f1c9591d17e394240d0bcf7ae004d46689b6b549888d1cd122027
+size 47266

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7870863dc873f84f0d2832d2f9771bbc4ce1bf365343755506834111d8dc36e
+size 47517

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:342a74ce066694bffe99092973e5e3c8d70d93f4f8a6c9b53aa54ad3b2efdfa6
+size 47920

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161a542b26abec70c2a2395d4d0eae8684a3f5885aef422a01057a5fb2f56d4d
+size 47635

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d007007ddf81f80748c45bc81122f3bc327845ea1ca7d308fba5dac50ef42db6
+size 48306

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c621cf7b26ed3120b2df467555c261976b4b71be653b233a419bc5f29bf92a
+size 47762

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48e030152c213f1cb9c41a86c174756884f548799b34a22386fb1ed1bfe4c0fc
+size 47993

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b11587ef51b451919d01f772d0d02a7476b31832e16fe712ae06ddd90092ac0
+size 48749

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb924d47353cf3201a456ee21391f544034f385bc20ac278e1174a533c9de45
+size 48849

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d7c272aee4ef4387ec564571b46157a7e9db5b74b00202390f572b53ee0ce10
+size 48724

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6464b8b0074daf76593fb64452b27fbcb60988a76bf72908dbb2e488b907844e
+size 48809

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e616a25547b1eb11bcfdffbfd68cc0e0da93e94b0b03b0f8f50fd13ba033f922
+size 49423

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7bce1b205803bd9dfd29a54b373433f011d8dff09c1dd1150907d00cf741f8
+size 49057

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856230377b662344eb7b0374b7032f90469d18b8c3b179b25108c0c1cd59e7ef
+size 48971

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab7cfcbf194536149ff3fa03f29a4683b85a69b1530a268a5c2445e0cfb9c80
+size 49939

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0eeb867ae88da5485882c4856f61d806d258fed749ad762a082153a9d70ae3e
+size 50722

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0014cc77aec3a7ba64be977d14395c62b3bf9f99a3cdac50061e2c8d7c4b7b03
+size 49462

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43146575d9e7af5873b107c70f78bbabe87c1e6e223df5e2c054bebf98e55352
+size 48594

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d1b0b3f758e98d165eb36ec311755db89f7f6bfab6a1330b0f05e2adff635c
+size 50037

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e6bd67324c7e52383bfe8126f1e06b0f81ec24fd2a163d001386118903f4aa
+size 50139

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4fa5fbeca17aa83183b1094b561237bda3203722f01ad7089c0be8edba2e3f9
+size 50243

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0663ec02c0b4e86ea11b7c998f65435f59b0fd4b44ccf3e7004363da4bdf57f8
+size 50849

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5263f682cb4a3de93f138155dc1f70595e2acad560b189234c8f8cce8666ba
+size 51054

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d666c294ae94aac9fe7545c52590151e53f979e85f50f4aac189478e694b5f4
+size 51116

--- a/tests/integration/assets/outputs_ref/test_float32_copy_blend/info
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_blend/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60478db6a50e848b9bfa56e1ca7b634a4d5bb44e613674a96c524be5b5479fbb
+size 1509

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8abda4dcb88e9f33eb7582fa146e00c63d761ab66ada27b1daf51d80acd6210
+size 44162

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90f724f5e729d02668b14eac6802af6f19a85d8f7072a9400c0d29ceb4c91de
+size 44257

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b8398bd30ac9f440b64777c7b6962b3c13c9af143ac6da7cdde15c747d3a84
+size 44497

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b780953eb3ab80a9f94288890de3f230d2f820d18a76845b346090bdc481c7
+size 43740

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48798b0f808dc5e0fc2ad074c13109820ccf50fcf79dbc1140626fef95917fc
+size 44282

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:329da58d5dedc7f78b7e0a8d0c692c42a9c0a9d7702e582582e293833143ffe7
+size 44086

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed74e85b4e4125dd1b9718de57a436e27a74cd1b707a56614c2e14c904bbfa6e
+size 44735

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7cc0b55aa845c6bf1b0286f67a931774e11904cb79ee82c4c423fe92c82353e
+size 44900

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37bc95bbbe71ed96d1b1df5850cf46b611d6d19e18cb293ef245e88b73c7b86
+size 45770

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5302b408b6f32fabb84e40ee4bfd99c17ac4465949278d4b34ed495e50f29099
+size 45033

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1f097e746620ab7575daa91e87914aa22f418ad6c647bb8d84dd26d17690977
+size 45874

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfcaa309b4268ddca089a4e529924d63d7baad03ecbbb6f6cfd274079017607f
+size 46720

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b411951f3bd04ded9a1a5bfe071a97124c62995d918b9f6b940933d550c6b6cf
+size 46149

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940e515678906e9d3bcdd463266187deef29d2eb9f14bcade02ff6dc78b80b0a
+size 46470

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9757c0c1c95a1c1d433a82f4986461b26af97af38af9d6b90adebcf1cf82c992
+size 46184

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f3417cc2ae68c72db5f65849dc1a66dace941c55ca2f375d4f1ed4582f2423
+size 46159

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6155833d77251180ebeff054b6b7f5a62565f2dd8ec23d006dbeb34ddd48f45
+size 46791

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82361878d5054684d2545534af585a45aacad7f446e934de00195621a788818
+size 46698

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe0f88e167753bd1c01cfe41a9d90bbf36d5f6938f167c7b6d028a75b2d0ee98
+size 47250

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63dc0711bb9421bb9978d0e9f4d2d1b6ad70ec7e996b3749dc7617689cb42098
+size 47634

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94248471f7959790f2734c91ae13bbf8b57e94b5a92cfe34a0d394f812698ebf
+size 46349

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50b9cc51b13cd53d019a8396c37afdfbd44fa247a66b979452fe3e3a2bd35e1
+size 46023

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8da2278c21d19d6a9e5c8fef87f0ef60407a274b27a0acda86a0dc342fbb718
+size 46764

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2033a90efbd331209e3e374f7b6f27499b3ac0d882042b751648d8f6fa4ee775
+size 46939

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ae8e30c439f180b81ea9e7a8fcf025af63d73b37f56cd31ac1a7ee4291f036
+size 48173

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f4eebdc04fc52a3c917f94745e23227326ada8ef7fb26e07ab7bb65f3b35f21
+size 47561

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb897e18b11f1c9591d17e394240d0bcf7ae004d46689b6b549888d1cd122027
+size 47266

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7870863dc873f84f0d2832d2f9771bbc4ce1bf365343755506834111d8dc36e
+size 47517

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:342a74ce066694bffe99092973e5e3c8d70d93f4f8a6c9b53aa54ad3b2efdfa6
+size 47920

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161a542b26abec70c2a2395d4d0eae8684a3f5885aef422a01057a5fb2f56d4d
+size 47635

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d007007ddf81f80748c45bc81122f3bc327845ea1ca7d308fba5dac50ef42db6
+size 48306

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c621cf7b26ed3120b2df467555c261976b4b71be653b233a419bc5f29bf92a
+size 47762

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48e030152c213f1cb9c41a86c174756884f548799b34a22386fb1ed1bfe4c0fc
+size 47993

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b11587ef51b451919d01f772d0d02a7476b31832e16fe712ae06ddd90092ac0
+size 48749

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb924d47353cf3201a456ee21391f544034f385bc20ac278e1174a533c9de45
+size 48849

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d7c272aee4ef4387ec564571b46157a7e9db5b74b00202390f572b53ee0ce10
+size 48724

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6464b8b0074daf76593fb64452b27fbcb60988a76bf72908dbb2e488b907844e
+size 48809

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e616a25547b1eb11bcfdffbfd68cc0e0da93e94b0b03b0f8f50fd13ba033f922
+size 49423

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7bce1b205803bd9dfd29a54b373433f011d8dff09c1dd1150907d00cf741f8
+size 49057

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856230377b662344eb7b0374b7032f90469d18b8c3b179b25108c0c1cd59e7ef
+size 48971

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab7cfcbf194536149ff3fa03f29a4683b85a69b1530a268a5c2445e0cfb9c80
+size 49939

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0eeb867ae88da5485882c4856f61d806d258fed749ad762a082153a9d70ae3e
+size 50722

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0014cc77aec3a7ba64be977d14395c62b3bf9f99a3cdac50061e2c8d7c4b7b03
+size 49462

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43146575d9e7af5873b107c70f78bbabe87c1e6e223df5e2c054bebf98e55352
+size 48594

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d1b0b3f758e98d165eb36ec311755db89f7f6bfab6a1330b0f05e2adff635c
+size 50037

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e6bd67324c7e52383bfe8126f1e06b0f81ec24fd2a163d001386118903f4aa
+size 50139

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4fa5fbeca17aa83183b1094b561237bda3203722f01ad7089c0be8edba2e3f9
+size 50243

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0663ec02c0b4e86ea11b7c998f65435f59b0fd4b44ccf3e7004363da4bdf57f8
+size 50849

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5263f682cb4a3de93f138155dc1f70595e2acad560b189234c8f8cce8666ba
+size 51054

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d666c294ae94aac9fe7545c52590151e53f979e85f50f4aac189478e694b5f4
+size 51116

--- a/tests/integration/assets/outputs_ref/test_float32_copy_crop/info
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_crop/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60478db6a50e848b9bfa56e1ca7b634a4d5bb44e613674a96c524be5b5479fbb
+size 1509

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8abda4dcb88e9f33eb7582fa146e00c63d761ab66ada27b1daf51d80acd6210
+size 44162

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90f724f5e729d02668b14eac6802af6f19a85d8f7072a9400c0d29ceb4c91de
+size 44257

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b8398bd30ac9f440b64777c7b6962b3c13c9af143ac6da7cdde15c747d3a84
+size 44497

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b780953eb3ab80a9f94288890de3f230d2f820d18a76845b346090bdc481c7
+size 43740

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48798b0f808dc5e0fc2ad074c13109820ccf50fcf79dbc1140626fef95917fc
+size 44282

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:329da58d5dedc7f78b7e0a8d0c692c42a9c0a9d7702e582582e293833143ffe7
+size 44086

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed74e85b4e4125dd1b9718de57a436e27a74cd1b707a56614c2e14c904bbfa6e
+size 44735

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7cc0b55aa845c6bf1b0286f67a931774e11904cb79ee82c4c423fe92c82353e
+size 44900

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37bc95bbbe71ed96d1b1df5850cf46b611d6d19e18cb293ef245e88b73c7b86
+size 45770

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5302b408b6f32fabb84e40ee4bfd99c17ac4465949278d4b34ed495e50f29099
+size 45033

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1f097e746620ab7575daa91e87914aa22f418ad6c647bb8d84dd26d17690977
+size 45874

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfcaa309b4268ddca089a4e529924d63d7baad03ecbbb6f6cfd274079017607f
+size 46720

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b411951f3bd04ded9a1a5bfe071a97124c62995d918b9f6b940933d550c6b6cf
+size 46149

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940e515678906e9d3bcdd463266187deef29d2eb9f14bcade02ff6dc78b80b0a
+size 46470

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9757c0c1c95a1c1d433a82f4986461b26af97af38af9d6b90adebcf1cf82c992
+size 46184

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f3417cc2ae68c72db5f65849dc1a66dace941c55ca2f375d4f1ed4582f2423
+size 46159

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6155833d77251180ebeff054b6b7f5a62565f2dd8ec23d006dbeb34ddd48f45
+size 46791

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c82361878d5054684d2545534af585a45aacad7f446e934de00195621a788818
+size 46698

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe0f88e167753bd1c01cfe41a9d90bbf36d5f6938f167c7b6d028a75b2d0ee98
+size 47250

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63dc0711bb9421bb9978d0e9f4d2d1b6ad70ec7e996b3749dc7617689cb42098
+size 47634

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94248471f7959790f2734c91ae13bbf8b57e94b5a92cfe34a0d394f812698ebf
+size 46349

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50b9cc51b13cd53d019a8396c37afdfbd44fa247a66b979452fe3e3a2bd35e1
+size 46023

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8da2278c21d19d6a9e5c8fef87f0ef60407a274b27a0acda86a0dc342fbb718
+size 46764

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2033a90efbd331209e3e374f7b6f27499b3ac0d882042b751648d8f6fa4ee775
+size 46939

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ae8e30c439f180b81ea9e7a8fcf025af63d73b37f56cd31ac1a7ee4291f036
+size 48173

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f4eebdc04fc52a3c917f94745e23227326ada8ef7fb26e07ab7bb65f3b35f21
+size 47561

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb897e18b11f1c9591d17e394240d0bcf7ae004d46689b6b549888d1cd122027
+size 47266

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7870863dc873f84f0d2832d2f9771bbc4ce1bf365343755506834111d8dc36e
+size 47517

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:342a74ce066694bffe99092973e5e3c8d70d93f4f8a6c9b53aa54ad3b2efdfa6
+size 47920

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:161a542b26abec70c2a2395d4d0eae8684a3f5885aef422a01057a5fb2f56d4d
+size 47635

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d007007ddf81f80748c45bc81122f3bc327845ea1ca7d308fba5dac50ef42db6
+size 48306

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c621cf7b26ed3120b2df467555c261976b4b71be653b233a419bc5f29bf92a
+size 47762

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48e030152c213f1cb9c41a86c174756884f548799b34a22386fb1ed1bfe4c0fc
+size 47993

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b11587ef51b451919d01f772d0d02a7476b31832e16fe712ae06ddd90092ac0
+size 48749

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb924d47353cf3201a456ee21391f544034f385bc20ac278e1174a533c9de45
+size 48849

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d7c272aee4ef4387ec564571b46157a7e9db5b74b00202390f572b53ee0ce10
+size 48724

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6464b8b0074daf76593fb64452b27fbcb60988a76bf72908dbb2e488b907844e
+size 48809

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e616a25547b1eb11bcfdffbfd68cc0e0da93e94b0b03b0f8f50fd13ba033f922
+size 49423

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7bce1b205803bd9dfd29a54b373433f011d8dff09c1dd1150907d00cf741f8
+size 49057

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856230377b662344eb7b0374b7032f90469d18b8c3b179b25108c0c1cd59e7ef
+size 48971

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab7cfcbf194536149ff3fa03f29a4683b85a69b1530a268a5c2445e0cfb9c80
+size 49939

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0eeb867ae88da5485882c4856f61d806d258fed749ad762a082153a9d70ae3e
+size 50722

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0014cc77aec3a7ba64be977d14395c62b3bf9f99a3cdac50061e2c8d7c4b7b03
+size 49462

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43146575d9e7af5873b107c70f78bbabe87c1e6e223df5e2c054bebf98e55352
+size 48594

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d1b0b3f758e98d165eb36ec311755db89f7f6bfab6a1330b0f05e2adff635c
+size 50037

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e6bd67324c7e52383bfe8126f1e06b0f81ec24fd2a163d001386118903f4aa
+size 50139

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4fa5fbeca17aa83183b1094b561237bda3203722f01ad7089c0be8edba2e3f9
+size 50243

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0663ec02c0b4e86ea11b7c998f65435f59b0fd4b44ccf3e7004363da4bdf57f8
+size 50849

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5263f682cb4a3de93f138155dc1f70595e2acad560b189234c8f8cce8666ba
+size 51054

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d666c294ae94aac9fe7545c52590151e53f979e85f50f4aac189478e694b5f4
+size 51116

--- a/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/info
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_multilevel/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60478db6a50e848b9bfa56e1ca7b634a4d5bb44e613674a96c524be5b5479fbb
+size 1509

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38ed6d6f589ec7fab9e53a0b1e1fe510732d5c68cd456badf472afb25084d534
+size 43623

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7427e6201ff137fd9e8049b046a4195504f70d9e2bb899eea6f4d71e9fc4c787
+size 43771

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bb0d17719de0d1b4dcea0abb134867112b441549029937954840429d1ca9757
+size 43909

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d3983eebfefccbb7cba4e960ab2a43ce6113db12822fdcc2a1ff361f3134ea1
+size 43313

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f32f76c67ef14402799c0619fe55a3f3f0249825dad5b7ecfa541e38c9ac3f65
+size 43840

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce49f306febd3b434ade1f0977342acff3851e1d741d50e06de0513f1dd7276b
+size 43611

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab79da91d069876b17b328fae37af28c6ccb5ca4b1d42879652bea6bf8f3e4e5
+size 44225

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d6138a583d801e752ed0e0849a2b85d6b072695d532a799dd700f25d4c2f014
+size 44499

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4e5d7569bc3c188a55e8303d27af727eeff61fdd46fc9a5a33b764d85fa2dce
+size 45276

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3c1642764b173c87fdf74d427f63ca4aed2ad8f6baf6adccb4b6ef4f8851d7
+size 44535

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4abc3e7d8edea47b680a8efeb4e5f0ec03a91446d27ef53a65b49934598d300d
+size 45378

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8035e743dc23f795c725da7cdb0ef448c61c4d4e6cad3c01ca53f561ab5b9ff6
+size 46164

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0695c1a57b975e6da99accd3d28415a9fde0705e40473f886a76524e19d5a6f
+size 45668

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9018f8eefa202921d8ad8c7440b3ae41075ca4bdd8f474a96a8e690d053d072c
+size 45932

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c656419c45199e0176392ec894b051f861a5db11f7d6089920b207b5f8384ad4
+size 45732

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f4d08605838a992dd0e9c723572fff8022cb36b1dd7385736ecff203caaadb3
+size 45704

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c8faeebfe94182b4ddfce5c1dc842070832d9325470a2541bb9d0efbe3c35de
+size 46302

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:873c862dc254c306e7d126d09b8d4e60a087d1bb3e970e818201e632100dd845
+size 46229

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9817f765144ababaf7a8cd9a3dcbb451d1a28146ffaf4ed05b2cc195b486392d
+size 46757

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2987ba1d3300a6d2483e36e7e472fef99c54e27cf176d8c4122236e91dbb4bc
+size 47128

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc48ac67a8668b3766f7a36f054e0c385b312fc4466a5abd9c54f7a97b74fc23
+size 45768

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54ca5bfe1835181ccacff96170817356e2f697865dd35d7d51096618c46ee75
+size 45471

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b8a11a73d2459d81f130359d018f259a82e35b531b8242a1c4f3e0eb3f097c
+size 46257

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a7352f8901dfc5265675f59976f360a755b6c25dbfc6002a43ed1362b6afe1f
+size 46298

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e121319b8a18e220d28aa5d93fc9f9120890d0ae60b7b446d6c126590973d91c
+size 47659

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdee64634e4ccf37caac57c76df7029c2e81df7bbc7443ed7bc5dcb481a583ad
+size 47297

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fc3ee706a6e55f0693b76a4412acc0ae58a7ba426eea4ffc5f7e6f9f9ef7f5b
+size 46848

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b502607edff5edd5fac78fe73a0261e214bab983aa6dc7edbe5021c91f706f7a
+size 46964

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89bd3da706db9ec1d39605323cce26472cdb865495602ac567d4599038ec2165
+size 47398

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7eda1595920f822dfdefd7d733f50e4b26c90ed5cd71230d8ddb8e511f5bbe5
+size 47188

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61c240bfc0ac03af435d2dea1f9b583e6eb7d45fc37c1c898482f0b40b080bf5
+size 47847

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071327ee843f834f132382b3f33522f46147e3b636e91f4530f07da1f09d8fe5
+size 47222

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f837db6c2914192fa6d79e8253e2c258c09f44312672bbf3c6066a3909b742fc
+size 47456

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:803c0e6db699349e7b1e9ef6637df37a43e0c82dbea30fe4e89775c610dbe4a2
+size 48225

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed411e9f8984c3979bcbb226affa93f9a360fa67ca262a7f288fe3561bcc3868
+size 48336

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b95af971153594e5f5189de3249277dcf64085f6763fa5411eb688bbb98ed9
+size 48217

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f39574c5c11c6e44931eaff2fa65f6e692d31692e4ba7cb45cac1ade209f3b6
+size 48265

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b249eb44651cf699ecdf042ed0770af79186b56a1e04a253632c85a189804f90
+size 48960

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac2d9b43c8351eb0f8fc8f9d2565a5aed3d02363b4e064d53ddd05d7532f589
+size 48569

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bde419264f3c5efca214bcf76c7711fbdaf0d5cb2841595fe85821d230db38a4
+size 48341

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9dcd6d0d6a04d4d1105889284fb94bb643d382937cd3c02a5fd556a52e72998
+size 49464

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70432fcec926914db71a09ede39a9d619340b5ac1135b8f3aee59dae0af7940d
+size 50251

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d7c8adf5200401344a5eab6e3f591d215ec2b992f0afc1d5aea6098daf1962b
+size 48930

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d9e943682e450ed9f20716e904fa19e859a2c9618fc848505430d40a2be2737
+size 48193

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b32c629745457c5ec31ed689df13a0a9dd564413885b1b33dd5facf5d4917e3
+size 49536

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66ef5366d5d8229712a7533c1fbd782de01c60e66fe64c1bd46aad102bcabf03
+size 49623

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2abe1bd9a7699692e1d69f1d69fa3a88fa7cecf2abaa1396e9b51c4432fe9be
+size 49713

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b3ace061049d1864beee92445c6caa481d2b373699993e07f8956b8818dced
+size 50359

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6c08a233dd71b914216aa0d325291d595b7fe882e3eeeb7ce1d2e93d5feac7a
+size 50586

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3552310b5b5e77b8d2c17c122ebe37b2dc3fa423851b864f3bfc2ab111566b33
+size 50593

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/info
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60478db6a50e848b9bfa56e1ca7b634a4d5bb44e613674a96c524be5b5479fbb
+size 1509

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38ed6d6f589ec7fab9e53a0b1e1fe510732d5c68cd456badf472afb25084d534
+size 43623

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7427e6201ff137fd9e8049b046a4195504f70d9e2bb899eea6f4d71e9fc4c787
+size 43771

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bb0d17719de0d1b4dcea0abb134867112b441549029937954840429d1ca9757
+size 43909

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d3983eebfefccbb7cba4e960ab2a43ce6113db12822fdcc2a1ff361f3134ea1
+size 43313

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f32f76c67ef14402799c0619fe55a3f3f0249825dad5b7ecfa541e38c9ac3f65
+size 43840

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce49f306febd3b434ade1f0977342acff3851e1d741d50e06de0513f1dd7276b
+size 43611

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab79da91d069876b17b328fae37af28c6ccb5ca4b1d42879652bea6bf8f3e4e5
+size 44225

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d6138a583d801e752ed0e0849a2b85d6b072695d532a799dd700f25d4c2f014
+size 44499

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4e5d7569bc3c188a55e8303d27af727eeff61fdd46fc9a5a33b764d85fa2dce
+size 45276

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3c1642764b173c87fdf74d427f63ca4aed2ad8f6baf6adccb4b6ef4f8851d7
+size 44535

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4abc3e7d8edea47b680a8efeb4e5f0ec03a91446d27ef53a65b49934598d300d
+size 45378

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8035e743dc23f795c725da7cdb0ef448c61c4d4e6cad3c01ca53f561ab5b9ff6
+size 46164

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0695c1a57b975e6da99accd3d28415a9fde0705e40473f886a76524e19d5a6f
+size 45668

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9018f8eefa202921d8ad8c7440b3ae41075ca4bdd8f474a96a8e690d053d072c
+size 45932

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c656419c45199e0176392ec894b051f861a5db11f7d6089920b207b5f8384ad4
+size 45732

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f4d08605838a992dd0e9c723572fff8022cb36b1dd7385736ecff203caaadb3
+size 45704

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c8faeebfe94182b4ddfce5c1dc842070832d9325470a2541bb9d0efbe3c35de
+size 46302

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:873c862dc254c306e7d126d09b8d4e60a087d1bb3e970e818201e632100dd845
+size 46229

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9817f765144ababaf7a8cd9a3dcbb451d1a28146ffaf4ed05b2cc195b486392d
+size 46757

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2987ba1d3300a6d2483e36e7e472fef99c54e27cf176d8c4122236e91dbb4bc
+size 47128

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc48ac67a8668b3766f7a36f054e0c385b312fc4466a5abd9c54f7a97b74fc23
+size 45768

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54ca5bfe1835181ccacff96170817356e2f697865dd35d7d51096618c46ee75
+size 45471

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b8a11a73d2459d81f130359d018f259a82e35b531b8242a1c4f3e0eb3f097c
+size 46257

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a7352f8901dfc5265675f59976f360a755b6c25dbfc6002a43ed1362b6afe1f
+size 46298

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e121319b8a18e220d28aa5d93fc9f9120890d0ae60b7b446d6c126590973d91c
+size 47659

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdee64634e4ccf37caac57c76df7029c2e81df7bbc7443ed7bc5dcb481a583ad
+size 47297

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fc3ee706a6e55f0693b76a4412acc0ae58a7ba426eea4ffc5f7e6f9f9ef7f5b
+size 46848

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b502607edff5edd5fac78fe73a0261e214bab983aa6dc7edbe5021c91f706f7a
+size 46964

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89bd3da706db9ec1d39605323cce26472cdb865495602ac567d4599038ec2165
+size 47398

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7eda1595920f822dfdefd7d733f50e4b26c90ed5cd71230d8ddb8e511f5bbe5
+size 47188

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61c240bfc0ac03af435d2dea1f9b583e6eb7d45fc37c1c898482f0b40b080bf5
+size 47847

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071327ee843f834f132382b3f33522f46147e3b636e91f4530f07da1f09d8fe5
+size 47222

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f837db6c2914192fa6d79e8253e2c258c09f44312672bbf3c6066a3909b742fc
+size 47456

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:803c0e6db699349e7b1e9ef6637df37a43e0c82dbea30fe4e89775c610dbe4a2
+size 48225

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed411e9f8984c3979bcbb226affa93f9a360fa67ca262a7f288fe3561bcc3868
+size 48336

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81b95af971153594e5f5189de3249277dcf64085f6763fa5411eb688bbb98ed9
+size 48217

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f39574c5c11c6e44931eaff2fa65f6e692d31692e4ba7cb45cac1ade209f3b6
+size 48265

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b249eb44651cf699ecdf042ed0770af79186b56a1e04a253632c85a189804f90
+size 48960

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac2d9b43c8351eb0f8fc8f9d2565a5aed3d02363b4e064d53ddd05d7532f589
+size 48569

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bde419264f3c5efca214bcf76c7711fbdaf0d5cb2841595fe85821d230db38a4
+size 48341

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9dcd6d0d6a04d4d1105889284fb94bb643d382937cd3c02a5fd556a52e72998
+size 49464

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70432fcec926914db71a09ede39a9d619340b5ac1135b8f3aee59dae0af7940d
+size 50251

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d7c8adf5200401344a5eab6e3f591d215ec2b992f0afc1d5aea6098daf1962b
+size 48930

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d9e943682e450ed9f20716e904fa19e859a2c9618fc848505430d40a2be2737
+size 48193

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b32c629745457c5ec31ed689df13a0a9dd564413885b1b33dd5facf5d4917e3
+size 49536

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66ef5366d5d8229712a7533c1fbd782de01c60e66fe64c1bd46aad102bcabf03
+size 49623

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2abe1bd9a7699692e1d69f1d69fa3a88fa7cecf2abaa1396e9b51c4432fe9be
+size 49713

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b3ace061049d1864beee92445c6caa481d2b373699993e07f8956b8818dced
+size 50359

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6c08a233dd71b914216aa0d325291d595b7fe882e3eeeb7ce1d2e93d5feac7a
+size 50586

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3552310b5b5e77b8d2c17c122ebe37b2dc3fa423851b864f3bfc2ab111566b33
+size 50593

--- a/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/info
+++ b/tests/integration/assets/outputs_ref/test_float32_copy_writeproc_multilevel/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60478db6a50e848b9bfa56e1ca7b634a4d5bb44e613674a96c524be5b5479fbb
+size 1509

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef02c821275ca8ad1cfa3fdf94eeabb4bc763864a90bd4878355933e48121be
+size 25858

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4263408f43a2403d29a4f4fa1e44af4e2767ca58cd1dcebd8b46398b1503900f
+size 25860

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c3aa102d9de9ac6ff9dceb4994d894ebb8c2feb1bd52e8502a232cc80e26371
+size 26153

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8daa585d08f873414ca5f6fd0c0349443d93e691e441faa800242e2c79d1568
+size 25904

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ddacede4167df2d8679421e498e969b30ce02ce88e91b17a6b2520c7a84481
+size 25988

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83b4bcb69c92392b0071773f6555e8ef8272f719e4c2baa6e46a3481a2cd686
+size 26070

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31f15d9cc8574b281ddcf156670ee55361c163dbb516ddc28b162bb08e3b3e30
+size 26395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe8cd9087d3e7235a07af5ca3186b145189de81acdbdf810350d4a4190e23e0
+size 26370

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb3310c5c5da6ecfa42a22debb8039c8849a2c80bb414aa7b5189c36e729a5c
+size 26811

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069d4afe1a6fe99b802d3c8a1ee4a6745ccacd9731196204cc717b3a0bc78dd7
+size 26589

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f4e125284365b9d05c9ff640997b12adad816a18422a0d601b0261f7af2b81
+size 26998

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f79ed1350416a35516fff1ccc86f316a8662e3707c93460c087232402ac2bc5
+size 27568

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6228419087915b48c6ec2edabb7ff12e1dfa1f4d9912b613f954fbb0a95bf7f8
+size 27362

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2eca20b22aeaa6a225fd7fdfd8dacd9916f6d577ba464d1bc7f5c5ca2dc4e5e
+size 27398

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f891f1ba02d06ed11d779f29cb57c331d9751c3e815714f49eabbd8e9fb66081
+size 27256

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8955a89fd8e7d632ced8202f6b01aea2261f16a3ebb141168f6f5718990e3b30
+size 27407

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17c415fedfed5a93d085c23259c2ca6c5123cb58b569832c7c6bf7775d6f03ac
+size 27638

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f2def0d4733cf74d8fc5d27bbf2de51882850a9f8e47c5ad7d0636e6d8b619
+size 27620

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20abe76d7281346f84498261fb42be7b3eabe00db3b96eb08780e2256f45a7c
+size 27960

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b233f630c1ec14abd0c90e5b20c6324d8c3724fc58a1abb049377700a53272c6
+size 28098

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c090c90a6221269ffeb96ed40fa94bba1e39fd803fa905799be625132853f4af
+size 27230

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3deacf1948ce4631bdbb8592bfd281727b979312125beb0be39640bedc262d0
+size 27056

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8754ec3990cef6b614278f4d0273a43dff3b165bbec18aadfa4115d2cda1afd6
+size 27603

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3313f697b479fa8c8395266f74ab98da17e15f1737fa380581d13266e3d85a
+size 27776

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9484ed7d372882b2d2c6880ec6060877a42b70674335aca599ac3a36e719d67
+size 28414

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156377bf37e671f568897a260087160907f0016c72d1b4556842e3e227662b3e
+size 28083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e68d8986ba9b4c26947a681fc109cda26afc270503c46bcc3cd900f17c58b8b
+size 27831

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05d0642192f4d3433b2e76a565b4142eb7edc0534353279b4a121dc54651e00
+size 28049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97e43378e18bfff9f8f9c17c1fe50de7c03ee040e9276949222f1be4e4ca33de
+size 28353

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f717226631d6f3a6b7730b91c27261e3f16806897a68c09eb951a13db2f3dc62
+size 28147

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0bb628ed914af660b0be30f089905147f314d80b218c9b110b73393a97fc9c2
+size 28705

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86eea13c286112124e6610ff1fb50e98a4439c5af9c291261bbb364c7599321
+size 28790

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0b8d5083c6b8968b98e92b0d896e8e32d556804caeed538ce13aced4e92c66a
+size 28501

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d19a6e4332ee529961ece65235e15b6d01eb3f5a9109d561f5bcade16bd8c9
+size 29049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d7887a28dafa2cd7d05cac1cb62928f906a37c1cb644ae56bd1fc01d86f1370
+size 29044

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b58462a562797a07a8be1d9dd87b3de33778095cb4839109cbefc75b38bddb5c
+size 28920

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fda956ea5b3bb6fc4fcf9e01e6c225160c4b258ff350a0f4b4a0368a5ee6e8d
+size 29074

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eeb8bddc7c96c49ddb21b52813bcf8f0aef32d1058a92248338d345f70770d
+size 29196

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c4306824ad32db80c6188b131481ea6f783f6cefa16a09c826ebbadfd82e18
+size 29041

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:628839a2b3fca16ba6c08e40bbf96c23e5388b0f4690c1cf2ef6d8a7dba3a4ce
+size 29083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bdbbd62826f3f2ea736ce45070f33846ef0f34bd98ebdca2ee320878c37d95
+size 29680

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81386374fed6c7a37c9f499347bd48564349466b126273bd78afcd7e401d0cb
+size 30167

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b3107c1fe7042b121a2cfdb559c0c0966cd236e4b0aa4df500a1cb1163f2f1
+size 29468

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d9c56f30a1ce02ea79df74c4599a3cc9be003e99b1d832ea14a555443182ea
+size 29160

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e44f722d266064bc929f44a90553bee890abc0da756f9eb31f3ce45d11f5d73
+size 29737

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c8405074db04d80f9769e3af51859d6f29daad94d191a7aeb6214ead5f7ee56
+size 29723

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f0c40674845bc8124b8b1a93a357128254fe292cd859f0a6f3150cf982af20
+size 30060

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0aab618b9e3d37546b3c07635088631e18d52ad92ebc5009a6d3f58ba231405
+size 30395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4886826785e012315006d26bf7b6aecbf51e7f61891889659df6413a34b5e30
+size 30349

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6cdb7a8780f63fd100dea52ca5afd61ac0010356ba3923b8ce8021c49444590
+size 30548

--- a/tests/integration/assets/outputs_ref/test_uint8_copy/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef02c821275ca8ad1cfa3fdf94eeabb4bc763864a90bd4878355933e48121be
+size 25858

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4263408f43a2403d29a4f4fa1e44af4e2767ca58cd1dcebd8b46398b1503900f
+size 25860

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c3aa102d9de9ac6ff9dceb4994d894ebb8c2feb1bd52e8502a232cc80e26371
+size 26153

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8daa585d08f873414ca5f6fd0c0349443d93e691e441faa800242e2c79d1568
+size 25904

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ddacede4167df2d8679421e498e969b30ce02ce88e91b17a6b2520c7a84481
+size 25988

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83b4bcb69c92392b0071773f6555e8ef8272f719e4c2baa6e46a3481a2cd686
+size 26070

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31f15d9cc8574b281ddcf156670ee55361c163dbb516ddc28b162bb08e3b3e30
+size 26395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe8cd9087d3e7235a07af5ca3186b145189de81acdbdf810350d4a4190e23e0
+size 26370

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb3310c5c5da6ecfa42a22debb8039c8849a2c80bb414aa7b5189c36e729a5c
+size 26811

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069d4afe1a6fe99b802d3c8a1ee4a6745ccacd9731196204cc717b3a0bc78dd7
+size 26589

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f4e125284365b9d05c9ff640997b12adad816a18422a0d601b0261f7af2b81
+size 26998

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f79ed1350416a35516fff1ccc86f316a8662e3707c93460c087232402ac2bc5
+size 27568

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6228419087915b48c6ec2edabb7ff12e1dfa1f4d9912b613f954fbb0a95bf7f8
+size 27362

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2eca20b22aeaa6a225fd7fdfd8dacd9916f6d577ba464d1bc7f5c5ca2dc4e5e
+size 27398

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f891f1ba02d06ed11d779f29cb57c331d9751c3e815714f49eabbd8e9fb66081
+size 27256

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8955a89fd8e7d632ced8202f6b01aea2261f16a3ebb141168f6f5718990e3b30
+size 27407

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17c415fedfed5a93d085c23259c2ca6c5123cb58b569832c7c6bf7775d6f03ac
+size 27638

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f2def0d4733cf74d8fc5d27bbf2de51882850a9f8e47c5ad7d0636e6d8b619
+size 27620

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20abe76d7281346f84498261fb42be7b3eabe00db3b96eb08780e2256f45a7c
+size 27960

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b233f630c1ec14abd0c90e5b20c6324d8c3724fc58a1abb049377700a53272c6
+size 28098

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c090c90a6221269ffeb96ed40fa94bba1e39fd803fa905799be625132853f4af
+size 27230

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3deacf1948ce4631bdbb8592bfd281727b979312125beb0be39640bedc262d0
+size 27056

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8754ec3990cef6b614278f4d0273a43dff3b165bbec18aadfa4115d2cda1afd6
+size 27603

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3313f697b479fa8c8395266f74ab98da17e15f1737fa380581d13266e3d85a
+size 27776

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9484ed7d372882b2d2c6880ec6060877a42b70674335aca599ac3a36e719d67
+size 28414

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156377bf37e671f568897a260087160907f0016c72d1b4556842e3e227662b3e
+size 28083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e68d8986ba9b4c26947a681fc109cda26afc270503c46bcc3cd900f17c58b8b
+size 27831

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05d0642192f4d3433b2e76a565b4142eb7edc0534353279b4a121dc54651e00
+size 28049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97e43378e18bfff9f8f9c17c1fe50de7c03ee040e9276949222f1be4e4ca33de
+size 28353

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f717226631d6f3a6b7730b91c27261e3f16806897a68c09eb951a13db2f3dc62
+size 28147

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0bb628ed914af660b0be30f089905147f314d80b218c9b110b73393a97fc9c2
+size 28705

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86eea13c286112124e6610ff1fb50e98a4439c5af9c291261bbb364c7599321
+size 28790

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0b8d5083c6b8968b98e92b0d896e8e32d556804caeed538ce13aced4e92c66a
+size 28501

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d19a6e4332ee529961ece65235e15b6d01eb3f5a9109d561f5bcade16bd8c9
+size 29049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d7887a28dafa2cd7d05cac1cb62928f906a37c1cb644ae56bd1fc01d86f1370
+size 29044

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b58462a562797a07a8be1d9dd87b3de33778095cb4839109cbefc75b38bddb5c
+size 28920

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fda956ea5b3bb6fc4fcf9e01e6c225160c4b258ff350a0f4b4a0368a5ee6e8d
+size 29074

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eeb8bddc7c96c49ddb21b52813bcf8f0aef32d1058a92248338d345f70770d
+size 29196

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c4306824ad32db80c6188b131481ea6f783f6cefa16a09c826ebbadfd82e18
+size 29041

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:628839a2b3fca16ba6c08e40bbf96c23e5388b0f4690c1cf2ef6d8a7dba3a4ce
+size 29083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bdbbd62826f3f2ea736ce45070f33846ef0f34bd98ebdca2ee320878c37d95
+size 29680

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81386374fed6c7a37c9f499347bd48564349466b126273bd78afcd7e401d0cb
+size 30167

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b3107c1fe7042b121a2cfdb559c0c0966cd236e4b0aa4df500a1cb1163f2f1
+size 29468

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d9c56f30a1ce02ea79df74c4599a3cc9be003e99b1d832ea14a555443182ea
+size 29160

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e44f722d266064bc929f44a90553bee890abc0da756f9eb31f3ce45d11f5d73
+size 29737

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c8405074db04d80f9769e3af51859d6f29daad94d191a7aeb6214ead5f7ee56
+size 29723

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f0c40674845bc8124b8b1a93a357128254fe292cd859f0a6f3150cf982af20
+size 30060

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0aab618b9e3d37546b3c07635088631e18d52ad92ebc5009a6d3f58ba231405
+size 30395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4886826785e012315006d26bf7b6aecbf51e7f61891889659df6413a34b5e30
+size 30349

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6cdb7a8780f63fd100dea52ca5afd61ac0010356ba3923b8ce8021c49444590
+size 30548

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_blend/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_blend/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef02c821275ca8ad1cfa3fdf94eeabb4bc763864a90bd4878355933e48121be
+size 25858

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4263408f43a2403d29a4f4fa1e44af4e2767ca58cd1dcebd8b46398b1503900f
+size 25860

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c3aa102d9de9ac6ff9dceb4994d894ebb8c2feb1bd52e8502a232cc80e26371
+size 26153

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8daa585d08f873414ca5f6fd0c0349443d93e691e441faa800242e2c79d1568
+size 25904

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ddacede4167df2d8679421e498e969b30ce02ce88e91b17a6b2520c7a84481
+size 25988

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83b4bcb69c92392b0071773f6555e8ef8272f719e4c2baa6e46a3481a2cd686
+size 26070

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31f15d9cc8574b281ddcf156670ee55361c163dbb516ddc28b162bb08e3b3e30
+size 26395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe8cd9087d3e7235a07af5ca3186b145189de81acdbdf810350d4a4190e23e0
+size 26370

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb3310c5c5da6ecfa42a22debb8039c8849a2c80bb414aa7b5189c36e729a5c
+size 26811

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069d4afe1a6fe99b802d3c8a1ee4a6745ccacd9731196204cc717b3a0bc78dd7
+size 26589

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f4e125284365b9d05c9ff640997b12adad816a18422a0d601b0261f7af2b81
+size 26998

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f79ed1350416a35516fff1ccc86f316a8662e3707c93460c087232402ac2bc5
+size 27568

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6228419087915b48c6ec2edabb7ff12e1dfa1f4d9912b613f954fbb0a95bf7f8
+size 27362

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2eca20b22aeaa6a225fd7fdfd8dacd9916f6d577ba464d1bc7f5c5ca2dc4e5e
+size 27398

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f891f1ba02d06ed11d779f29cb57c331d9751c3e815714f49eabbd8e9fb66081
+size 27256

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8955a89fd8e7d632ced8202f6b01aea2261f16a3ebb141168f6f5718990e3b30
+size 27407

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17c415fedfed5a93d085c23259c2ca6c5123cb58b569832c7c6bf7775d6f03ac
+size 27638

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f2def0d4733cf74d8fc5d27bbf2de51882850a9f8e47c5ad7d0636e6d8b619
+size 27620

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20abe76d7281346f84498261fb42be7b3eabe00db3b96eb08780e2256f45a7c
+size 27960

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b233f630c1ec14abd0c90e5b20c6324d8c3724fc58a1abb049377700a53272c6
+size 28098

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c090c90a6221269ffeb96ed40fa94bba1e39fd803fa905799be625132853f4af
+size 27230

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3deacf1948ce4631bdbb8592bfd281727b979312125beb0be39640bedc262d0
+size 27056

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8754ec3990cef6b614278f4d0273a43dff3b165bbec18aadfa4115d2cda1afd6
+size 27603

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3313f697b479fa8c8395266f74ab98da17e15f1737fa380581d13266e3d85a
+size 27776

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9484ed7d372882b2d2c6880ec6060877a42b70674335aca599ac3a36e719d67
+size 28414

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156377bf37e671f568897a260087160907f0016c72d1b4556842e3e227662b3e
+size 28083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e68d8986ba9b4c26947a681fc109cda26afc270503c46bcc3cd900f17c58b8b
+size 27831

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05d0642192f4d3433b2e76a565b4142eb7edc0534353279b4a121dc54651e00
+size 28049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97e43378e18bfff9f8f9c17c1fe50de7c03ee040e9276949222f1be4e4ca33de
+size 28353

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f717226631d6f3a6b7730b91c27261e3f16806897a68c09eb951a13db2f3dc62
+size 28147

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0bb628ed914af660b0be30f089905147f314d80b218c9b110b73393a97fc9c2
+size 28705

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86eea13c286112124e6610ff1fb50e98a4439c5af9c291261bbb364c7599321
+size 28790

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0b8d5083c6b8968b98e92b0d896e8e32d556804caeed538ce13aced4e92c66a
+size 28501

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d19a6e4332ee529961ece65235e15b6d01eb3f5a9109d561f5bcade16bd8c9
+size 29049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d7887a28dafa2cd7d05cac1cb62928f906a37c1cb644ae56bd1fc01d86f1370
+size 29044

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b58462a562797a07a8be1d9dd87b3de33778095cb4839109cbefc75b38bddb5c
+size 28920

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fda956ea5b3bb6fc4fcf9e01e6c225160c4b258ff350a0f4b4a0368a5ee6e8d
+size 29074

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eeb8bddc7c96c49ddb21b52813bcf8f0aef32d1058a92248338d345f70770d
+size 29196

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c4306824ad32db80c6188b131481ea6f783f6cefa16a09c826ebbadfd82e18
+size 29041

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:628839a2b3fca16ba6c08e40bbf96c23e5388b0f4690c1cf2ef6d8a7dba3a4ce
+size 29083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bdbbd62826f3f2ea736ce45070f33846ef0f34bd98ebdca2ee320878c37d95
+size 29680

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81386374fed6c7a37c9f499347bd48564349466b126273bd78afcd7e401d0cb
+size 30167

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b3107c1fe7042b121a2cfdb559c0c0966cd236e4b0aa4df500a1cb1163f2f1
+size 29468

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d9c56f30a1ce02ea79df74c4599a3cc9be003e99b1d832ea14a555443182ea
+size 29160

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e44f722d266064bc929f44a90553bee890abc0da756f9eb31f3ce45d11f5d73
+size 29737

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c8405074db04d80f9769e3af51859d6f29daad94d191a7aeb6214ead5f7ee56
+size 29723

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f0c40674845bc8124b8b1a93a357128254fe292cd859f0a6f3150cf982af20
+size 30060

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0aab618b9e3d37546b3c07635088631e18d52ad92ebc5009a6d3f58ba231405
+size 30395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4886826785e012315006d26bf7b6aecbf51e7f61891889659df6413a34b5e30
+size 30349

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6cdb7a8780f63fd100dea52ca5afd61ac0010356ba3923b8ce8021c49444590
+size 30548

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_crop/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_crop/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ef02c821275ca8ad1cfa3fdf94eeabb4bc763864a90bd4878355933e48121be
+size 25858

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4263408f43a2403d29a4f4fa1e44af4e2767ca58cd1dcebd8b46398b1503900f
+size 25860

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c3aa102d9de9ac6ff9dceb4994d894ebb8c2feb1bd52e8502a232cc80e26371
+size 26153

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8daa585d08f873414ca5f6fd0c0349443d93e691e441faa800242e2c79d1568
+size 25904

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ddacede4167df2d8679421e498e969b30ce02ce88e91b17a6b2520c7a84481
+size 25988

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83b4bcb69c92392b0071773f6555e8ef8272f719e4c2baa6e46a3481a2cd686
+size 26070

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31f15d9cc8574b281ddcf156670ee55361c163dbb516ddc28b162bb08e3b3e30
+size 26395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe8cd9087d3e7235a07af5ca3186b145189de81acdbdf810350d4a4190e23e0
+size 26370

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb3310c5c5da6ecfa42a22debb8039c8849a2c80bb414aa7b5189c36e729a5c
+size 26811

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069d4afe1a6fe99b802d3c8a1ee4a6745ccacd9731196204cc717b3a0bc78dd7
+size 26589

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f4e125284365b9d05c9ff640997b12adad816a18422a0d601b0261f7af2b81
+size 26998

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f79ed1350416a35516fff1ccc86f316a8662e3707c93460c087232402ac2bc5
+size 27568

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6228419087915b48c6ec2edabb7ff12e1dfa1f4d9912b613f954fbb0a95bf7f8
+size 27362

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2eca20b22aeaa6a225fd7fdfd8dacd9916f6d577ba464d1bc7f5c5ca2dc4e5e
+size 27398

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f891f1ba02d06ed11d779f29cb57c331d9751c3e815714f49eabbd8e9fb66081
+size 27256

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8955a89fd8e7d632ced8202f6b01aea2261f16a3ebb141168f6f5718990e3b30
+size 27407

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17c415fedfed5a93d085c23259c2ca6c5123cb58b569832c7c6bf7775d6f03ac
+size 27638

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f2def0d4733cf74d8fc5d27bbf2de51882850a9f8e47c5ad7d0636e6d8b619
+size 27620

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20abe76d7281346f84498261fb42be7b3eabe00db3b96eb08780e2256f45a7c
+size 27960

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b233f630c1ec14abd0c90e5b20c6324d8c3724fc58a1abb049377700a53272c6
+size 28098

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c090c90a6221269ffeb96ed40fa94bba1e39fd803fa905799be625132853f4af
+size 27230

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3deacf1948ce4631bdbb8592bfd281727b979312125beb0be39640bedc262d0
+size 27056

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8754ec3990cef6b614278f4d0273a43dff3b165bbec18aadfa4115d2cda1afd6
+size 27603

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3313f697b479fa8c8395266f74ab98da17e15f1737fa380581d13266e3d85a
+size 27776

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9484ed7d372882b2d2c6880ec6060877a42b70674335aca599ac3a36e719d67
+size 28414

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156377bf37e671f568897a260087160907f0016c72d1b4556842e3e227662b3e
+size 28083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e68d8986ba9b4c26947a681fc109cda26afc270503c46bcc3cd900f17c58b8b
+size 27831

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05d0642192f4d3433b2e76a565b4142eb7edc0534353279b4a121dc54651e00
+size 28049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97e43378e18bfff9f8f9c17c1fe50de7c03ee040e9276949222f1be4e4ca33de
+size 28353

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f717226631d6f3a6b7730b91c27261e3f16806897a68c09eb951a13db2f3dc62
+size 28147

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0bb628ed914af660b0be30f089905147f314d80b218c9b110b73393a97fc9c2
+size 28705

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86eea13c286112124e6610ff1fb50e98a4439c5af9c291261bbb364c7599321
+size 28790

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0b8d5083c6b8968b98e92b0d896e8e32d556804caeed538ce13aced4e92c66a
+size 28501

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d19a6e4332ee529961ece65235e15b6d01eb3f5a9109d561f5bcade16bd8c9
+size 29049

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d7887a28dafa2cd7d05cac1cb62928f906a37c1cb644ae56bd1fc01d86f1370
+size 29044

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b58462a562797a07a8be1d9dd87b3de33778095cb4839109cbefc75b38bddb5c
+size 28920

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fda956ea5b3bb6fc4fcf9e01e6c225160c4b258ff350a0f4b4a0368a5ee6e8d
+size 29074

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eeb8bddc7c96c49ddb21b52813bcf8f0aef32d1058a92248338d345f70770d
+size 29196

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92c4306824ad32db80c6188b131481ea6f783f6cefa16a09c826ebbadfd82e18
+size 29041

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:628839a2b3fca16ba6c08e40bbf96c23e5388b0f4690c1cf2ef6d8a7dba3a4ce
+size 29083

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bdbbd62826f3f2ea736ce45070f33846ef0f34bd98ebdca2ee320878c37d95
+size 29680

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81386374fed6c7a37c9f499347bd48564349466b126273bd78afcd7e401d0cb
+size 30167

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b3107c1fe7042b121a2cfdb559c0c0966cd236e4b0aa4df500a1cb1163f2f1
+size 29468

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d9c56f30a1ce02ea79df74c4599a3cc9be003e99b1d832ea14a555443182ea
+size 29160

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e44f722d266064bc929f44a90553bee890abc0da756f9eb31f3ce45d11f5d73
+size 29737

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c8405074db04d80f9769e3af51859d6f29daad94d191a7aeb6214ead5f7ee56
+size 29723

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2f0c40674845bc8124b8b1a93a357128254fe292cd859f0a6f3150cf982af20
+size 30060

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0aab618b9e3d37546b3c07635088631e18d52ad92ebc5009a6d3f58ba231405
+size 30395

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4886826785e012315006d26bf7b6aecbf51e7f61891889659df6413a34b5e30
+size 30349

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6cdb7a8780f63fd100dea52ca5afd61ac0010356ba3923b8ce8021c49444590
+size 30548

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_multilevel/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a8d08601233d4ccb06f7d8db74a48f7ea726e60bd39d5a724c7502718c00950
+size 25860

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5905a4303fa0b937a1835ebc79cf84400445ea7dc7c13de8fb78cf4723b75a71
+size 25889

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05c2405efbf10c44d6ad86f5259727d5ec09d7c5601abb4db296fb2c146ce12e
+size 26195

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88ee5f51c8a5752cb902cee03d9f61bb93d77ea7d7ea60d8184701b08efb9392
+size 25906

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096df1369062778f01a74e3d365cccfe72e4ba7c685afa8e333b6d2157c29cbc
+size 25990

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9291566be4d7f961be8114b1e050e8b20603aeecc7aa5b54ee4af92cdfcd0af2
+size 26072

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d98833d55d8b6f47131562ee67d84cba675c232bd1f322b9ba7c9d3b115873f
+size 26397

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a106f2ab2af2460b60ce0c243ce9a3ac65197e50ef0e0889dfc73391d38a314a
+size 26383

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72afe2be6b73ca3798ccee94cc2a66068ede21e19875135507e539a391288533
+size 26802

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a66012e76ae2bf2e9275732ba9d335f60a1e0de4016e622f6185c6f38fc8ff66
+size 26591

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aedcdf21c2c22555cffacb651805f1e8307521b0a399d78bd1e96315f6e68c32
+size 26968

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f7e0e25ffdfff5a2fe59869a66908cbcf82a2e502b9f52fb83cde1bdf3502ad
+size 27571

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8511dfbc1c58480801ea41c97a52b852d4b9ba9fc3221866e57101c16ca532f0
+size 27364

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2140bdb3d121fa5f8177c3d553cc64400103e3b856bc62519019d6dc9ced34
+size 27512

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07d852c9c4d877153a6867bb52b4104999ff627e56a77dff5ca8e5535082e2b5
+size 27203

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aac04094ac6fd2503ca9f58d5849c0f11fc3d5cf48f9b1f2836a2e72fa92002
+size 27408

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc03d9e294c806ede015b10a0d81db2dfb2d9e2e1d97446d64c540428b2576b6
+size 27640

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b62ea2a3a9a4d05da4c5b6199a6e445a3de4dacdf7d7cd03ed590dfd5941bb9
+size 27763

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56999c172809bea9e9876f94c8885501801c0658d845fb8f9dd95761d0125336
+size 27962

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:472ef287a847f64cd70710c8a45ec7ddd44543aeddf35c5e2d01cc0f00e05618
+size 28100

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a631500d62b91712f191660e1977a3448cc86fb3ee09aca8dfceca25d047e49
+size 27232

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33925b22c999a892ac65b5c1bdffd0c1040c35c2269697206a08f636a03f8fbb
+size 27067

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:134418266f065ce7549848bf5d57df650729d36690f84944b51b4944a2f26e63
+size 27638

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef11c35b7e7e054c466fc28bc292e1ea92f7894da977fde752e6f968c5ad70bc
+size 27778

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad9b0997ee852aad11e28fb30cddcd975b1ff7950845cff688a3f78988e1e75e
+size 28417

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48dbd98a43a11e54f7cb4c1ab739694a4e22751f662e9e48b013499fe54245e4
+size 28086

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cbc3607430b67c2b7844be15eb6cee63c07cd4f5d52f73434e0b6ab27b55c5a
+size 27993

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbbd8ee0888245756a3fd99c82443331deec85a5290076e53d424a0c5d4677d6
+size 28142

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b3b333cc84600d299530032feabe65590d318b3d4c4f2da4bfb041ddaea6771
+size 28432

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73782946c3ccf824ebf4955d99d5d89c3f9af483b7dfd8cf9e981b752734ba0f
+size 28149

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b703300827c81aba054545ac5246fdfee10b6b592055e8050b616aab9cf1cbcc
+size 28707

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52dbc8f3cec70bccc61c545963d7b5900431126c6c9f66b5c57b6adc1d756f90
+size 28792

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3951aef5a6bcf50e7f7c7eebc5d7ff5b3f7b44c9c5ea624b60fd3081d4015d3
+size 28503

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ee0d9dfa47a8bb9ede30a8ae448e724e96319a3b8fc170a457830ec3b3f6a2
+size 29061

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27f1b2a48856bc4468a6475553a8541aff43d0209172023d59f908153149898d
+size 28982

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:255bb6e866cf0b8e0966047dbea8845313e43aa19f25535ee49ba13e3988ec5c
+size 28923

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:266402e51745f048d3625da76965836780386c6f4975c69c98fcdde9aa131867
+size 29077

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a230dc19ffd73b9dffbdf8beed42aa20b74d959a38b97715bd0eb9120cdf5ea8
+size 29198

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a54cef798b5b719b111c5d93de21ec32eea8f859dca48d441261cc0c2c14bc1
+size 29043

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c656b513d43693c6b37c54e0902d5bdd4a1d1c36becd0831a004532cc4cea61a
+size 29085

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04af5ebbbf9a6a2a434fe1b404bf7cb74be93b3de2f6d2cddf6dde002a74841b
+size 29682

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079abe684a92e5c1a72f8d403ecb3ac92c65444ea145ed099cc025b23288a171
+size 30170

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a675747ad3ef107982bf2d1c349dcfd535a801f54017cc337099474782ab91d1
+size 29470

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19797716542bcc1db2cb4ecedba30035b49fb6ac768cb349a98f635520c3fe5f
+size 29161

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bb994eb392a01725477fa5b4ed43129f6e3fb12f18b0319dadf59e7b18ccbdc
+size 29740

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a08ce571764dd1fbde3bf6eb1b3e6656afb80949aa6d757d2693ef770c72d6d5
+size 29725

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a36f67e4530b84fd3027d37174b1adf06b0c0e5271cba4aafa7e5c2aae37b081
+size 30062

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a0e0607af559a45a99fc4dbd784c84106cdb19b74364fa1595e68921115b884
+size 30398

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7f49c98b5b53c8b83cf469d511a42319c9a473990c2ce1abed8825810178615
+size 30331

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:920b53da77527d5a44df997d09bf4584b4469ad56b7d2fcb11adc997e0a211a3
+size 30627

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a8d08601233d4ccb06f7d8db74a48f7ea726e60bd39d5a724c7502718c00950
+size 25860

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5905a4303fa0b937a1835ebc79cf84400445ea7dc7c13de8fb78cf4723b75a71
+size 25889

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05c2405efbf10c44d6ad86f5259727d5ec09d7c5601abb4db296fb2c146ce12e
+size 26195

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88ee5f51c8a5752cb902cee03d9f61bb93d77ea7d7ea60d8184701b08efb9392
+size 25906

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096df1369062778f01a74e3d365cccfe72e4ba7c685afa8e333b6d2157c29cbc
+size 25990

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2005-2006.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9291566be4d7f961be8114b1e050e8b20603aeecc7aa5b54ee4af92cdfcd0af2
+size 26072

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2006-2007.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d98833d55d8b6f47131562ee67d84cba675c232bd1f322b9ba7c9d3b115873f
+size 26397

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2007-2008.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a106f2ab2af2460b60ce0c243ce9a3ac65197e50ef0e0889dfc73391d38a314a
+size 26383

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2008-2009.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72afe2be6b73ca3798ccee94cc2a66068ede21e19875135507e539a391288533
+size 26802

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2009-2010.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a66012e76ae2bf2e9275732ba9d335f60a1e0de4016e622f6185c6f38fc8ff66
+size 26591

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2010-2011.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aedcdf21c2c22555cffacb651805f1e8307521b0a399d78bd1e96315f6e68c32
+size 26968

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2011-2012.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f7e0e25ffdfff5a2fe59869a66908cbcf82a2e502b9f52fb83cde1bdf3502ad
+size 27571

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2012-2013.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8511dfbc1c58480801ea41c97a52b852d4b9ba9fc3221866e57101c16ca532f0
+size 27364

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2013-2014.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2140bdb3d121fa5f8177c3d553cc64400103e3b856bc62519019d6dc9ced34
+size 27512

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2014-2015.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07d852c9c4d877153a6867bb52b4104999ff627e56a77dff5ca8e5535082e2b5
+size 27203

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2015-2016.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aac04094ac6fd2503ca9f58d5849c0f11fc3d5cf48f9b1f2836a2e72fa92002
+size 27408

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2016-2017.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc03d9e294c806ede015b10a0d81db2dfb2d9e2e1d97446d64c540428b2576b6
+size 27640

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2017-2018.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b62ea2a3a9a4d05da4c5b6199a6e445a3de4dacdf7d7cd03ed590dfd5941bb9
+size 27763

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2018-2019.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56999c172809bea9e9876f94c8885501801c0658d845fb8f9dd95761d0125336
+size 27962

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2019-2020.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:472ef287a847f64cd70710c8a45ec7ddd44543aeddf35c5e2d01cc0f00e05618
+size 28100

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2020-2021.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a631500d62b91712f191660e1977a3448cc86fb3ee09aca8dfceca25d047e49
+size 27232

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2021-2022.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33925b22c999a892ac65b5c1bdffd0c1040c35c2269697206a08f636a03f8fbb
+size 27067

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2022-2023.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:134418266f065ce7549848bf5d57df650729d36690f84944b51b4944a2f26e63
+size 27638

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2023-2024.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef11c35b7e7e054c466fc28bc292e1ea92f7894da977fde752e6f968c5ad70bc
+size 27778

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2024-2025.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad9b0997ee852aad11e28fb30cddcd975b1ff7950845cff688a3f78988e1e75e
+size 28417

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2025-2026.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48dbd98a43a11e54f7cb4c1ab739694a4e22751f662e9e48b013499fe54245e4
+size 28086

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2026-2027.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cbc3607430b67c2b7844be15eb6cee63c07cd4f5d52f73434e0b6ab27b55c5a
+size 27993

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2027-2028.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbbd8ee0888245756a3fd99c82443331deec85a5290076e53d424a0c5d4677d6
+size 28142

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2028-2029.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b3b333cc84600d299530032feabe65590d318b3d4c4f2da4bfb041ddaea6771
+size 28432

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2029-2030.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73782946c3ccf824ebf4955d99d5d89c3f9af483b7dfd8cf9e981b752734ba0f
+size 28149

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2030-2031.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b703300827c81aba054545ac5246fdfee10b6b592055e8050b616aab9cf1cbcc
+size 28707

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2031-2032.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52dbc8f3cec70bccc61c545963d7b5900431126c6c9f66b5c57b6adc1d756f90
+size 28792

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2032-2033.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3951aef5a6bcf50e7f7c7eebc5d7ff5b3f7b44c9c5ea624b60fd3081d4015d3
+size 28503

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2033-2034.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ee0d9dfa47a8bb9ede30a8ae448e724e96319a3b8fc170a457830ec3b3f6a2
+size 29061

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2034-2035.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27f1b2a48856bc4468a6475553a8541aff43d0209172023d59f908153149898d
+size 28982

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2035-2036.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:255bb6e866cf0b8e0966047dbea8845313e43aa19f25535ee49ba13e3988ec5c
+size 28923

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2036-2037.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:266402e51745f048d3625da76965836780386c6f4975c69c98fcdde9aa131867
+size 29077

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2037-2038.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a230dc19ffd73b9dffbdf8beed42aa20b74d959a38b97715bd0eb9120cdf5ea8
+size 29198

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2038-2039.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a54cef798b5b719b111c5d93de21ec32eea8f859dca48d441261cc0c2c14bc1
+size 29043

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2039-2040.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c656b513d43693c6b37c54e0902d5bdd4a1d1c36becd0831a004532cc4cea61a
+size 29085

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2040-2041.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04af5ebbbf9a6a2a434fe1b404bf7cb74be93b3de2f6d2cddf6dde002a74841b
+size 29682

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2041-2042.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079abe684a92e5c1a72f8d403ecb3ac92c65444ea145ed099cc025b23288a171
+size 30170

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2042-2043.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a675747ad3ef107982bf2d1c349dcfd535a801f54017cc337099474782ab91d1
+size 29470

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2043-2044.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19797716542bcc1db2cb4ecedba30035b49fb6ac768cb349a98f635520c3fe5f
+size 29161

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2044-2045.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bb994eb392a01725477fa5b4ed43129f6e3fb12f18b0319dadf59e7b18ccbdc
+size 29740

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2045-2046.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a08ce571764dd1fbde3bf6eb1b3e6656afb80949aa6d757d2693ef770c72d6d5
+size 29725

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2046-2047.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a36f67e4530b84fd3027d37174b1adf06b0c0e5271cba4aafa7e5c2aae37b081
+size 30062

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2047-2048.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a0e0607af559a45a99fc4dbd784c84106cdb19b74364fa1595e68921115b884
+size 30398

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2048-2049.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7f49c98b5b53c8b83cf469d511a42319c9a473990c2ce1abed8825810178615
+size 30331

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/128_128_40/2048-3072_2048-3072_2049-2050.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:920b53da77527d5a44df997d09bf4584b4469ad56b7d2fcb11adc997e0a211a3
+size 30627

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_writeproc_multilevel/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/subchunkable/specs/test_float32_copy.cue
+++ b/tests/integration/subchunkable/specs/test_float32_copy.cue
@@ -1,0 +1,36 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32"
+#DST_PATH: "tests/integration/assets/outputs/test_float32_copy"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1]]
+	processing_crop_pads: [[0, 0, 0]]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_float32_copy_blend.cue
+++ b/tests/integration/subchunkable/specs/test_float32_copy_blend.cue
@@ -1,0 +1,39 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32"
+#DST_PATH: "tests/integration/assets/outputs/test_float32_copy_blend"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_blend_pads: [[0, 0, 0], [64, 64, 0]]
+	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
+	max_reduction_chunk_sizes: [[1024, 1024, 1], [1024, 1024, 1]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_float32_copy_crop.cue
+++ b/tests/integration/subchunkable/specs/test_float32_copy_crop.cue
@@ -1,0 +1,39 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32"
+#DST_PATH: "tests/integration/assets/outputs/test_float32_copy_crop"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
+	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
+	max_reduction_chunk_sizes: [[1024, 1024, 1], [1024, 1024, 1]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_float32_copy_multilevel.cue
+++ b/tests/integration/subchunkable/specs/test_float32_copy_multilevel.cue
@@ -1,0 +1,37 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32"
+#DST_PATH: "tests/integration/assets/outputs/test_float32_copy_multilevel"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_float32_copy_writeproc.cue
+++ b/tests/integration/subchunkable/specs/test_float32_copy_writeproc.cue
@@ -1,0 +1,41 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32"
+#DST_PATH: "tests/integration/assets/outputs/test_float32_copy_writeproc"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1]]
+	processing_crop_pads: [[0, 0, 0]]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		write_procs: [
+			{
+				"@type":    "lambda"
+				lambda_str: "lambda data: data + 1"
+			}]
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_float32_copy_writeproc_multilevel.cue
+++ b/tests/integration/subchunkable/specs/test_float32_copy_writeproc_multilevel.cue
@@ -1,0 +1,42 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050_float32"
+#DST_PATH: "tests/integration/assets/outputs/test_float32_copy_writeproc_multilevel"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		write_procs: [
+			{
+				"@type":    "lambda"
+				lambda_str: "lambda data: data + 1"
+			}]
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_uint8_copy.cue
+++ b/tests/integration/subchunkable/specs/test_uint8_copy.cue
@@ -1,0 +1,36 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050"
+#DST_PATH: "tests/integration/assets/outputs/test_uint8_copy"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1]]
+	processing_crop_pads: [[0, 0, 0]]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_uint8_copy_blend.cue
+++ b/tests/integration/subchunkable/specs/test_uint8_copy_blend.cue
@@ -1,0 +1,39 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050"
+#DST_PATH: "tests/integration/assets/outputs/test_uint8_copy_blend"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_blend_pads: [[0, 0, 0], [64, 64, 0]]
+	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
+	max_reduction_chunk_sizes: [[1024, 1024, 1], [1024, 1024, 1]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_uint8_copy_crop.cue
+++ b/tests/integration/subchunkable/specs/test_uint8_copy_crop.cue
@@ -1,0 +1,39 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050"
+#DST_PATH: "tests/integration/assets/outputs/test_uint8_copy_crop"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
+	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
+	max_reduction_chunk_sizes: [[1024, 1024, 1], [1024, 1024, 1]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_uint8_copy_multilevel.cue
+++ b/tests/integration/subchunkable/specs/test_uint8_copy_multilevel.cue
@@ -1,0 +1,37 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050"
+#DST_PATH: "tests/integration/assets/outputs/test_uint8_copy_multilevel"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_uint8_copy_writeproc.cue
+++ b/tests/integration/subchunkable/specs/test_uint8_copy_writeproc.cue
@@ -1,0 +1,41 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050"
+#DST_PATH: "tests/integration/assets/outputs/test_uint8_copy_writeproc"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1]]
+	processing_crop_pads: [[0, 0, 0]]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		write_procs: [
+			{
+				"@type":    "lambda"
+				lambda_str: "lambda data: data + 1"
+			}]
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/specs/test_uint8_copy_writeproc_multilevel.cue
+++ b/tests/integration/subchunkable/specs/test_uint8_copy_writeproc_multilevel.cue
@@ -1,0 +1,42 @@
+#SRC_PATH: "tests/integration/assets/inputs/fafb_v15_img_128_128_40-2048-3072_2000-2050"
+#DST_PATH: "tests/integration/assets/outputs/test_uint8_copy_writeproc_multilevel"
+
+#BBOX: {
+	"@type": "BBox3D.from_coords"
+	start_coord: [64 * 1024, 64 * 1024, 2000]
+	end_coord: [96 * 1024, 96 * 1024, 2050]
+	resolution: [4, 4, 40]
+}
+
+#FLOW: {
+	"@type": "build_subchunkable_apply_flow"
+	fn: {
+		"@type":    "lambda"
+		lambda_str: "lambda src: src"
+	}
+	processing_chunk_sizes: [[1024, 1024, 1], [512, 512, 1]]
+	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
+	level_intermediaries_dirs: ["tests/integration/assets/temp/", "tests/integration/assets/temp/"]
+	expand_bbox: true
+	dst_resolution: [128, 128, 40]
+	bbox: #BBOX
+	op_kwargs: {
+		src: {
+			"@type": "build_cv_layer"
+			path:    #SRC_PATH
+		}
+	}
+	dst: {
+		"@type":             "build_cv_layer"
+		path:                #DST_PATH
+		info_reference_path: #SRC_PATH
+		write_procs: [
+			{
+				"@type":    "lambda"
+				lambda_str: "lambda data: data + 1"
+			}]
+	}
+}
+
+"@type": "mazepa.execute"
+target:  #FLOW

--- a/tests/integration/subchunkable/test_subchunkable.py
+++ b/tests/integration/subchunkable/test_subchunkable.py
@@ -1,0 +1,80 @@
+# pylint: disable=line-too-long, unused-import, too-many-return-statements
+import filecmp
+import os
+
+import pytest
+
+import zetta_utils
+from zetta_utils import builder, parsing
+from zetta_utils.geometry import BBox3D, Vec3D
+from zetta_utils.layer.volumetric import VolumetricIndex
+from zetta_utils.layer.volumetric.tensorstore import TSBackend
+
+
+# from https://stackoverflow.com/questions/4187564/recursively-compare-two-directories-to-ensure-they-have-the-same-files-and-subdi
+def are_dir_trees_equal(dir1, dir2):
+    """
+    Compare two directories recursively. Files in each directory are
+    assumed to be equal if their names and contents are equal.
+
+    @param dir1: First directory path
+    @param dir2: Second directory path
+
+    @return: True if the directory trees are the same and
+        there were no errors while accessing the directories or files,
+        False otherwise.
+    """
+
+    dirs_cmp = filecmp.dircmp(dir1, dir2)
+    if len(dirs_cmp.left_only) > 0:
+        print(f"File list mismatch: {dir1} has {dirs_cmp.left_only} files not found in {dir2}.")
+        return False
+    if len(dirs_cmp.right_only) > 0:
+        print(f"File list mismatch: {dir2} has {dirs_cmp.right_only} files not found in {dir1}.")
+        return False
+    if len(dirs_cmp.funny_files) > 0:
+        print(f"Cannot compare files: {dirs_cmp.funny_files}")
+        return False
+    (_, mismatch, errors) = filecmp.cmpfiles(dir1, dir2, dirs_cmp.common_files, shallow=False)
+    if len(mismatch) > 0:
+        print(f"Mismatched files: {mismatch}")
+        return False
+    if len(errors) > 0:
+        print(f"Errors in comparing files: {errors}")
+        return False
+    for common_dir in dirs_cmp.common_dirs:
+        new_dir1 = os.path.join(dir1, common_dir)
+        new_dir2 = os.path.join(dir2, common_dir)
+        if not are_dir_trees_equal(new_dir1, new_dir2):
+            return False
+    return True
+
+
+@pytest.mark.skipif(
+    "not config.getoption('--run-integration')",
+    reason="Only run when `--run-integration` is given",
+)
+@pytest.mark.parametrize(
+    "cue_name",
+    [
+        "test_uint8_copy",
+        "test_uint8_copy_multilevel",
+        "test_uint8_copy_blend",
+        "test_uint8_copy_crop",
+        "test_uint8_copy_writeproc",
+        "test_uint8_copy_writeproc_multilevel",
+        "test_float32_copy",
+        "test_float32_copy_multilevel",
+        "test_float32_copy_blend",
+        "test_float32_copy_crop",
+        "test_float32_copy_writeproc",
+        "test_float32_copy_writeproc_multilevel",
+    ],
+)
+def test_subchunkable(cue_name):
+    cue_path = f"./tests/integration/subchunkable/specs/{cue_name}.cue"
+    ref_path = f"./tests/integration/assets/outputs_ref/{cue_name}"
+    out_path = f"./tests/integration/assets/outputs/{cue_name}"
+    spec = zetta_utils.parsing.cue.load(cue_path)
+    zetta_utils.builder.build(spec)
+    assert are_dir_trees_equal(ref_path, out_path)


### PR DESCRIPTION
This commit does not fix the multilevel writeprocs yet, but the tests for it are there.

The output comparison will tell you which files differ - I figured that there is little sense in returning the difference as tensors since the debugger will likely need to look at the volumes in neuroglancer anyway.