### PR TITLE
fix(to_torch): respect device setting for torch.Tensor

### DIFF
--- a/zetta_utils/tensor_ops/convert.py
+++ b/zetta_utils/tensor_ops/convert.py
@@ -28,7 +28,7 @@ def to_np(data: Tensor) -> npt.NDArray:
 
 
 @typechecked
-def to_torch(data: Tensor, device: torch.types.Device = "cpu") -> torch.Tensor:
+def to_torch(data: Tensor, device: torch.types.Device = None) -> torch.Tensor:
     """Convert the given tensor to `torch.Tensor`.
 
     :param data: Input tensor_ops.
@@ -37,7 +37,7 @@ def to_torch(data: Tensor, device: torch.types.Device = "cpu") -> torch.Tensor:
 
     """
     if isinstance(data, torch.Tensor):
-        result = data
+        result = data.to(device=device)  # type: ignore # pytorch bug
     else:
         assert isinstance(data, np.ndarray)
         if data.dtype == np.uint64:


### PR DESCRIPTION
Current behavior ignores the desired `device` for `torch.Tensor` input. Change of default value to `None` to keep the current device and not accidentally move a GPU tensor back to CPU