### PR TITLE
feat: `translation_granularity` for field-adjusted download

### DIFF
--- a/zetta_utils/mazepa_layer_processing/alignment/common.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/common.py
@@ -38,7 +38,7 @@ def translation_adjusted_download(
         xy_translation = cast(
             tuple[int, int],
             tuple(
-                translation_granularity * (e // translation_granularity)
+                translation_granularity * round(e / translation_granularity)
                 for e in xy_translation_raw
             ),
         )

--- a/zetta_utils/mazepa_layer_processing/alignment/common.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import overload
+from typing import cast, overload
 
 import torch
 
@@ -11,16 +11,17 @@ from zetta_utils.layer.volumetric import VolumetricIndex, VolumetricLayer
 
 @overload
 def translation_adjusted_download(
-    idx: VolumetricIndex, src: VolumetricLayer, field: VolumetricLayer
+    idx: VolumetricIndex,
+    src: VolumetricLayer,
+    field: VolumetricLayer,
+    translation_granularity: int = ...,
 ) -> tuple[torch.Tensor, torch.Tensor, tuple[int, int]]:
     ...
 
 
 @overload
 def translation_adjusted_download(
-    idx: VolumetricIndex,
-    src: VolumetricLayer,
-    field: None,
+    idx: VolumetricIndex, src: VolumetricLayer, field: None, translation_granularity: int = ...
 ) -> tuple[torch.Tensor, None, tuple[int, int]]:
     ...
 
@@ -29,10 +30,18 @@ def translation_adjusted_download(
     idx: VolumetricIndex,
     src: VolumetricLayer,
     field: VolumetricLayer | None,
+    translation_granularity: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[int, int]]:
     if field is not None:
         field_data = field[idx]
-        xy_translation = alignment.field.profile_field2d_percentile(field_data)
+        xy_translation_raw = alignment.field.profile_field2d_percentile(field_data)
+        xy_translation = cast(
+            tuple[int, int],
+            tuple(
+                translation_granularity * (e // translation_granularity)
+                for e in xy_translation_raw
+            ),
+        )
 
         field_data[0] -= xy_translation[0]
         field_data[1] -= xy_translation[1]

--- a/zetta_utils/mazepa_layer_processing/alignment/warp_operation.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/warp_operation.py
@@ -22,6 +22,7 @@ class WarpOperation:
     crop_pad: Sequence[int] = (0, 0, 0)
     mask_value_thr: float = 0
     use_translation_adjustment: bool = True
+    translation_granularity: int = 1
 
     def get_operation_name(self):
         return f"WarpOperation<{self.mode}>"
@@ -49,6 +50,7 @@ class WarpOperation:
                 src=src,
                 field=field,
                 idx=idx_padded,
+                translation_granularity=self.translation_granularity,
             )
         else:
             src_data_raw = src[idx_padded]


### PR DESCRIPTION
Necessary for when field's `data_resolution` is coarser than the src `data_resolution`