### PR TITLE
fix(typing): Typeguard exceptions with X | Y union type under Python3.9

### DIFF
--- a/zetta_utils/builder/build.py
+++ b/zetta_utils/builder/build.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable, Final
+from typing import Any, Callable, Final, Optional
 
 import attrs
 from typeguard import typechecked
@@ -171,8 +171,7 @@ class BuilderPartial:
 
     spec: dict[str, Any]
     _built_spec_kwargs: dict[str, Any] | None = attrs.field(init=False, default=None)
-    name: str | None = None
-    # name: str | None = None
+    name: Optional[str] = None
 
     def get_display_name(self):  # pragma: no cover # pretty print
         if self.name is not None:

--- a/zetta_utils/builder/built_in_registrations.py
+++ b/zetta_utils/builder/built_in_registrations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import torch  # pylint: disable=unused-import
 
@@ -11,7 +11,7 @@ LAMBDA_STR_MAX_LENGTH: int = 80
 
 
 @register("lambda", False)
-def efficient_parse_lambda_str(lambda_str: str, name: str | None = None) -> Callable:
+def efficient_parse_lambda_str(lambda_str: str, name: Optional[str] = None) -> Callable:
     """Parses strings that are lambda functions"""
     if not isinstance(lambda_str, str):
         raise TypeError("`lambda_str` must be a string.")


### PR DESCRIPTION
`from __future__ import annotations`  helps for static type checkers, but runtime checks will fail, e.g.:

```
│ zetta/zetta_utils/zetta_utils/builder/built_in_registrations.py:23 in                            │
│ efficient_parse_lambda_str                                                                       │
│                                                                                                  │
│ zetta/zetta_utils/venv/lib/python3.9/site-packages/typeguard/_decorators.py:140                  │
│ in wrapper                                                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: isinstance() arg 2 must be a type or tuple of types
```