### PR TITLE
hotfix: Let skip_intermediaries through with crop_pad at the bottom, update to use expand_bbox_processing, and update old specs

### DIFF
--- a/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/0_warp_rigid_to_elastic.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/0_warp_rigid_to_elastic.cue
@@ -19,7 +19,7 @@
 	level_intermediaries_dirs: ['~/.sutils/tmp', '~/zutils/tmp']
 	processing_chunk_sizes: [[2 * #CHUNK, 2 * #CHUNK, 1], [#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[0, 0, 0], [#CROP_PAD, #CROP_PAD, 0]]
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: _
 	bbox:           #BBOX
 	src: {

--- a/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/1_downsample.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/1_downsample.cue
@@ -10,7 +10,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/2_encode.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/2_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads:   _

--- a/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/4_mask_encs.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/0_elastic/4_mask_encs.cue
@@ -12,7 +12,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/0_copy_data.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/0_copy_data.cue
@@ -11,7 +11,7 @@
 		"@type":    "lambda"
 		lambda_str: "lambda src: src"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [2048, 2048, 1]]
 	max_reduction_chunk_sizes: [1024 * 4, 1024 * 4, 1]
 	level_intermediaries_dirs: ['~/.zutils/', '~/.zutils/']

--- a/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/1_downsample.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/1_downsample.cue
@@ -7,7 +7,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	op: {

--- a/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/2_encode.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/2_encode.cue
@@ -105,7 +105,7 @@ import "math"
 		res_change_mult: [int, int, int]
 	}
 	dst_resolution: [int, int, int]
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024, 1024, 1]]
 	processing_crop_pads: [[0, 0, 0], [16, 16, 0]]
 	max_reduction_chunk_sizes: [4096, 4096, 1]

--- a/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/3_mask.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/1_rigid/3_mask.cue
@@ -7,7 +7,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/0_align.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/0_align.cue
@@ -239,7 +239,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -453,7 +453,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
 	processing_chunk_sizes: [[256, 256, #Z_END - #Z_START], [128, 128, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/1_align_big.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/1_align_big.cue
@@ -250,7 +250,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -495,7 +495,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/big_backup.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/big_backup.cue
@@ -250,7 +250,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -495,7 +495,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
 	processing_chunk_sizes: [[256, 256, #Z_END - #Z_START], [128, 128, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/coarse_aced_blending_bug.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/coarse_aced_blending_bug.cue
@@ -250,7 +250,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -495,7 +495,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
 	processing_chunk_sizes: [[256, 256, #Z_END - #Z_START], [136, 136, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/0_align_pairs.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/0_align_pairs.cue
@@ -313,7 +313,7 @@
 	}
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	processing_chunk_sizes: [[512, 512, #Z_END - #Z_START]]
 	processing_crop_pads: [[32, 32, 0]]
 	level_intermediaries_dirs: ["file://~/.zutil/tmp"]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/0_copy_initial_field.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/0_copy_initial_field.cue
@@ -16,7 +16,7 @@
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #BBOX
 	src: {

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/2_warp.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/2_warp.cue
@@ -15,7 +15,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/4_downsample.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/4_downsample.cue
@@ -10,7 +10,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/5_encode.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/0_prepare_stack/3_coarse_x1/tmp/6_mask_encs.cue
@@ -12,7 +12,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x0/0_copy_initial_field.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x0/0_copy_initial_field.cue
@@ -16,7 +16,7 @@
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #BBOX
 	src: {

--- a/specs/sergiy/inference/cns/1_coarse/x0/2_warp.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x0/2_warp.cue
@@ -15,7 +15,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/1_coarse/x0/4_downsample.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x0/4_downsample.cue
@@ -10,7 +10,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/1_coarse/x0/5_encode.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x0/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/1_coarse/x0/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x0/6_mask_encs.cue
@@ -12,7 +12,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x1/0_copy_initial_field.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x1/0_copy_initial_field.cue
@@ -16,7 +16,7 @@
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #BBOX
 	src: {

--- a/specs/sergiy/inference/cns/1_coarse/x1/2_warp.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x1/2_warp.cue
@@ -14,7 +14,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/1_coarse/x1/4_downsample.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x1/4_downsample.cue
@@ -9,7 +9,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/1_coarse/x1/5_encode.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x1/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/1_coarse/x1/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x1/6_mask_encs.cue
@@ -12,7 +12,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x1/9_combined.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x1/9_combined.cue
@@ -78,7 +78,7 @@ import "list"
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #ROI_BOUNDS
 	src: {
@@ -103,7 +103,7 @@ import "list"
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -176,7 +176,7 @@ import "list"
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -281,9 +281,9 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024 * 1, 1024 * 1, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -339,7 +339,7 @@ import "list"
 
 #MASK_ENCODINGS_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1]]
 	dst_resolution: _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x2/0_up_to_3300.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x2/0_up_to_3300.cue
@@ -78,7 +78,7 @@ import "list"
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #ROI_BOUNDS
 	src: {
@@ -103,7 +103,7 @@ import "list"
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -176,7 +176,7 @@ import "list"
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -281,9 +281,9 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024 * 1, 1024 * 1, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -339,7 +339,7 @@ import "list"
 
 #MASK_ENCODINGS_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1]]
 	dst_resolution: _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x2/1_3200_3498_surgery/0_align_pairs.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x2/1_3200_3498_surgery/0_align_pairs.cue
@@ -57,7 +57,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -67,7 +67,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -78,7 +78,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -172,7 +172,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -236,7 +236,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -270,7 +270,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -297,7 +297,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -328,7 +328,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -436,7 +436,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/1_coarse/x2/1_3200_3498_surgery/1_relax.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x2/1_3200_3498_surgery/1_relax.cue
@@ -84,7 +84,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -231,7 +231,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 
@@ -314,7 +314,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/1_coarse/x2/1_3200_3498_surgery/2_fill_data.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x2/1_3200_3498_surgery/2_fill_data.cue
@@ -78,7 +78,7 @@ import "list"
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #ROI_BOUNDS
 	src: {
@@ -105,7 +105,7 @@ import "list"
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -178,7 +178,7 @@ import "list"
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -283,9 +283,9 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024 * 1, 1024 * 1, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -341,7 +341,7 @@ import "list"
 
 #MASK_ENCODINGS_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1]]
 	dst_resolution: _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x2/2_after_3498.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x2/2_after_3498.cue
@@ -78,7 +78,7 @@ import "list"
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [256, 256, 45]
 	bbox: #ROI_BOUNDS
 	src: {
@@ -103,7 +103,7 @@ import "list"
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -176,7 +176,7 @@ import "list"
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -281,9 +281,9 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024 * 1, 1024 * 1, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
@@ -339,7 +339,7 @@ import "list"
 
 #MASK_ENCODINGS_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1]]
 	dst_resolution: _
 	fn: {

--- a/specs/sergiy/inference/cns/1_coarse/x2/9_tissue_mask_test.cue
+++ b/specs/sergiy/inference/cns/1_coarse/x2/9_tissue_mask_test.cue
@@ -22,7 +22,7 @@ import "list"
 	}
 	processing_chunk_sizes: [[2 * 1024, 2 * 1024, 1]]
 	processing_crop_pads: [[0, 1024, 1024]]
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [32, 32, 45]
 	bbox: #ROI_BOUNDS
 

--- a/specs/sergiy/inference/cns/2_med/v1/0_align.cue
+++ b/specs/sergiy/inference/cns/2_med/v1/0_align.cue
@@ -242,7 +242,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -456,7 +456,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/2_med/v1/1_combine_fields.cue
+++ b/specs/sergiy/inference/cns/2_med/v1/1_combine_fields.cue
@@ -17,7 +17,7 @@
 		"@type": "WarpOperation"
 		mode:    "field"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v1/2_warp.cue
+++ b/specs/sergiy/inference/cns/2_med/v1/2_warp.cue
@@ -15,7 +15,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v1/4_downsample.cue
+++ b/specs/sergiy/inference/cns/2_med/v1/4_downsample.cue
@@ -9,7 +9,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/2_med/v1/5_encode.cue
+++ b/specs/sergiy/inference/cns/2_med/v1/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/2_med/v1/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/2_med/v1/6_mask_encs.cue
@@ -13,7 +13,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/2_med/v2/0_align.cue
+++ b/specs/sergiy/inference/cns/2_med/v2/0_align.cue
@@ -97,7 +97,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -107,7 +107,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -138,7 +138,7 @@
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -249,7 +249,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -463,7 +463,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/2_med/v2/1_combine_fields.cue
+++ b/specs/sergiy/inference/cns/2_med/v2/1_combine_fields.cue
@@ -17,7 +17,7 @@
 		"@type": "WarpOperation"
 		mode:    "field"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v2/2_warp.cue
+++ b/specs/sergiy/inference/cns/2_med/v2/2_warp.cue
@@ -15,7 +15,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v2/4_downsample.cue
+++ b/specs/sergiy/inference/cns/2_med/v2/4_downsample.cue
@@ -9,7 +9,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/2_med/v2/5_encode.cue
+++ b/specs/sergiy/inference/cns/2_med/v2/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/2_med/v2/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/2_med/v2/6_mask_encs.cue
@@ -13,7 +13,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/2_med/v3/0_align_blocks.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/0_align_blocks.cue
@@ -92,7 +92,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -102,7 +102,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -113,7 +113,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -124,7 +124,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -209,7 +209,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -297,7 +297,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -331,7 +331,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -358,7 +358,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -389,7 +389,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -612,7 +612,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 
@@ -674,7 +674,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/1_invert_afields.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/1_invert_afields.cue
@@ -19,7 +19,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[512, 512, 1], [64, 64, 1]]
 	max_reduction_chunk_sizes: [512, 512, 1]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0.cue
@@ -110,7 +110,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -120,7 +120,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -131,7 +131,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -142,7 +142,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -227,7 +227,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -314,7 +314,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
@@ -348,7 +348,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -375,7 +375,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -407,7 +407,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -607,7 +607,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -663,7 +663,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_1024nm.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_1024nm.cue
@@ -111,7 +111,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -121,7 +121,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -132,7 +132,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -143,7 +143,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -228,7 +228,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -316,7 +316,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -350,7 +350,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -377,7 +377,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -409,7 +409,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -625,7 +625,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -687,7 +687,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_512nm.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_512nm.cue
@@ -109,7 +109,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -119,7 +119,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -130,7 +130,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -141,7 +141,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -226,7 +226,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -313,7 +313,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -347,7 +347,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -374,7 +374,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -406,7 +406,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -606,7 +606,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[64, 64, #Z_END - #Z_START], [44, 44, #Z_END - #Z_START]]
@@ -662,7 +662,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_iter1000.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_iter1000.cue
@@ -110,7 +110,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -120,7 +120,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -131,7 +131,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -142,7 +142,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -227,7 +227,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -314,7 +314,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -348,7 +348,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -375,7 +375,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -407,7 +407,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -607,7 +607,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -663,7 +663,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_pair_alignment.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/0_pair_alignment.cue
@@ -106,7 +106,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -116,7 +116,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -127,7 +127,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -138,7 +138,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -223,7 +223,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -311,7 +311,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -345,7 +345,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -372,7 +372,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -404,7 +404,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -620,7 +620,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -682,7 +682,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/1.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/1.cue
@@ -109,7 +109,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -119,7 +119,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -130,7 +130,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -141,7 +141,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -226,7 +226,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -313,7 +313,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -347,7 +347,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -374,7 +374,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -406,7 +406,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -606,7 +606,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -662,7 +662,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/1_1024nm.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/1_1024nm.cue
@@ -111,7 +111,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -121,7 +121,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -132,7 +132,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -143,7 +143,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -228,7 +228,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -316,7 +316,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -350,7 +350,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -377,7 +377,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -409,7 +409,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -625,7 +625,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -687,7 +687,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/1_debug_blend.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/1_debug_blend.cue
@@ -111,7 +111,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -121,7 +121,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -132,7 +132,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -143,7 +143,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -228,7 +228,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -316,7 +316,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -350,7 +350,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -377,7 +377,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -409,7 +409,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -629,7 +629,7 @@
 		"@type":    "lambda"
 		lambda_str: "lambda yo: yo"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -676,7 +676,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/2.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/2.cue
@@ -103,7 +103,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -113,7 +113,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -124,7 +124,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -135,7 +135,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -220,7 +220,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -307,7 +307,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -341,7 +341,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -368,7 +368,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -400,7 +400,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -600,7 +600,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -656,7 +656,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/2_2024nm.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/2_2024nm.cue
@@ -106,7 +106,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -116,7 +116,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -127,7 +127,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -138,7 +138,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -223,7 +223,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -311,7 +311,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -345,7 +345,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -372,7 +372,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -404,7 +404,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -620,7 +620,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -682,7 +682,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/3.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/3.cue
@@ -107,7 +107,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -117,7 +117,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -128,7 +128,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -139,7 +139,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -224,7 +224,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -311,7 +311,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -345,7 +345,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -372,7 +372,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -404,7 +404,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -604,7 +604,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -660,7 +660,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/debug/0_stuck.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/0_blocks/debug/0_stuck.cue
@@ -46,7 +46,7 @@
 #DOWNSAMPLE_FLOW: {
 	"@type":     "build_subchunkable_apply_flow"
 	bbox:        _
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/1_combine_fields.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/1_combine_fields.cue
@@ -17,7 +17,7 @@
 		"@type": "WarpOperation"
 		mode:    "field"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/1_invert_afields.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/1_invert_afields.cue
@@ -19,7 +19,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[512, 512, 1], [64, 64, 1]]
 	max_reduction_chunk_sizes: [512, 512, 1]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/2_warp.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/2_warp.cue
@@ -15,7 +15,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/4_downsample.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/4_downsample.cue
@@ -9,7 +9,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/5_encode.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/6_mask_encs.cue
@@ -13,7 +13,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing: true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/2_med/v3/9_old/\
+++ b/specs/sergiy/inference/cns/2_med/v3/9_old/\
@@ -30,7 +30,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024, 1024, 1]]
 	//max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]

--- a/specs/sergiy/inference/cns/2_med/v3/extract_m2m_fields.cue
+++ b/specs/sergiy/inference/cns/2_med/v3/extract_m2m_fields.cue
@@ -34,7 +34,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[512, 512, 1]]
 	//max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]

--- a/specs/sergiy/inference/cns/3_fine/v0/0_align.cue
+++ b/specs/sergiy/inference/cns/3_fine/v0/0_align.cue
@@ -310,7 +310,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -554,7 +554,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [32, 32, 45]
 	bbox: #BBOX
 	processing_chunk_sizes: [[512, 512, #Z_END - #Z_START], [288, 288, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/3_fine/v0/tmp.cue
+++ b/specs/sergiy/inference/cns/3_fine/v0/tmp.cue
@@ -306,7 +306,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[256, 256, 0]]
 	processing_chunk_sizes: [[2048, 2048, 1]]
 	//chunk_size: [512, 512, 1]
@@ -464,7 +464,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [32, 32, 45]
 	bbox: #BBOX
 	processing_chunk_sizes: [[256, 256, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/3_fine/v1/0_align.cue
+++ b/specs/sergiy/inference/cns/3_fine/v1/0_align.cue
@@ -193,7 +193,7 @@
 	"@type":        "ComputeFieldStage"
 	dst_resolution: _
 
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [2048, 2048, 1]]
 	max_reduction_chunk_sizes: [1024 * 4, 1024 * 4, 1]
@@ -306,7 +306,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [2048, 2048, 1]]
 	max_reduction_chunk_sizes: [1024 * 4, 1024 * 4, 1]
@@ -555,7 +555,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [32, 32, 45]
 	bbox: #BBOX
 	processing_chunk_sizes: [[512, 512, #Z_END - #Z_START], [288, 288, #Z_END - #Z_START]]

--- a/specs/sergiy/inference/cns/3_fine/v1/1_combine_fields.cue
+++ b/specs/sergiy/inference/cns/3_fine/v1/1_combine_fields.cue
@@ -18,7 +18,7 @@
 		"@type": "WarpOperation"
 		mode:    "field"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/3_fine/v1/2_warp.cue
+++ b/specs/sergiy/inference/cns/3_fine/v1/2_warp.cue
@@ -13,7 +13,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [2048, 2048, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]

--- a/specs/sergiy/inference/cns/3_fine/v1/3_downsample.cue
+++ b/specs/sergiy/inference/cns/3_fine/v1/3_downsample.cue
@@ -9,7 +9,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/0_align_pairs.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/0_align_pairs.cue
@@ -214,7 +214,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -269,7 +269,7 @@
 
 #WARP_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	op: {
 		"@type": "WarpOperation"
 		mode:    _
@@ -306,7 +306,7 @@
 
 #INVERT_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	fn: {"@type": "invert_field", "@mode": "partial"}
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -330,7 +330,7 @@
 
 #ENCODE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	fn: {
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
@@ -361,7 +361,7 @@
 
 #MISD_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	fn: {
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
@@ -450,7 +450,7 @@
 
 #CREATE_TISSUE_MASK: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	bbox:        _
 	fn: {
 		"@type": "apply_mask_fn"
@@ -502,7 +502,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/1_relax.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/1_relax.cue
@@ -97,7 +97,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -107,7 +107,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -118,7 +118,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -129,7 +129,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -214,7 +214,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -302,7 +302,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -336,7 +336,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -363,7 +363,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -394,7 +394,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -617,7 +617,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 
@@ -694,7 +694,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/experimental/1_extend_misd_masks.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/experimental/1_extend_misd_masks.cue
@@ -26,7 +26,7 @@
 #GET_RIGIDITY_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "get_rigidity_map", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	// processing_chunk_sizes: [[4 * 1024, 4 * 1024, 1], [1024, 1024, 1]]
 	// max_reduction_chunk_sizes: [4 * 1024, 4 * 1024, 1]
@@ -106,7 +106,7 @@
 		"@type": "WarpOperation"
 		mode:    "mask"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -138,7 +138,7 @@
 		"@mode":    "partial"
 		fill_value: 255.0
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]

--- a/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/experimental/3_relax_blocks_combined_masks.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/0_stage0/experimental/3_relax_blocks_combined_masks.cue
@@ -95,7 +95,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -105,7 +105,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -116,7 +116,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -127,7 +127,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -212,7 +212,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -300,7 +300,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -334,7 +334,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -361,7 +361,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -392,7 +392,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -615,7 +615,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 
@@ -679,7 +679,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/0_invert_stage0_afield.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/0_invert_stage0_afield.cue
@@ -19,7 +19,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[512, 512, 1], [64, 64, 1]]
 	max_reduction_chunk_sizes: [512, 512, 1]

--- a/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/1_extract_stage1_rfields.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/1_extract_stage1_rfields.cue
@@ -33,7 +33,7 @@
 
 #WARP_FLOW_TMPL: {
 	"@type":                   "build_subchunkable_apply_flow"
-	expand_bbox:               true
+	expand_bbox_processing:               true
 	processing_crop_pads:      _ | *null
 	processing_chunk_sizes:    _
 	level_intermediaries_dirs: _ | *null

--- a/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/2_warp_masks.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/2_warp_masks.cue
@@ -39,7 +39,7 @@
 
 #WARP_FLOW_TMPL: {
 	"@type":                   "build_subchunkable_apply_flow"
-	expand_bbox:               true
+	expand_bbox_processing:               true
 	processing_crop_pads:      _ | *null
 	processing_chunk_sizes:    _
 	level_intermediaries_dirs: _ | *null

--- a/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/3_stage1_relax.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/3_stage1_relax.cue
@@ -119,7 +119,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -275,7 +275,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 

--- a/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/4_remake_masks.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/1_stage1/4_remake_masks.cue
@@ -116,7 +116,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]

--- a/specs/sergiy/inference/cns/4_multistage/v0/2_final_render/0_combine_fields.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/2_final_render/0_combine_fields.cue
@@ -27,7 +27,7 @@
 		mode:                    "field"
 		translation_granularity: 16
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[8 * 1024, 8 * 1024, 1], [2048, 2048, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	level_intermediaries_dirs: ["~/.zutils/tmp", "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/2_final_render/2_downsample.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/2_final_render/2_downsample.cue
@@ -12,7 +12,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	op: {

--- a/specs/sergiy/inference/cns/4_multistage/v0/8_compute_rigidity.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/8_compute_rigidity.cue
@@ -26,7 +26,7 @@
 #GET_RIGIDITY_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "get_rigidity_map", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	// processing_chunk_sizes: [[4 * 1024, 4 * 1024, 1], [1024, 1024, 1]]
 	// max_reduction_chunk_sizes: [4 * 1024, 4 * 1024, 1]
@@ -106,7 +106,7 @@
 		"@type": "WarpOperation"
 		mode:    "mask"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -138,7 +138,7 @@
 		"@mode":    "partial"
 		fill_value: 255.0
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0.cue
@@ -110,7 +110,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -120,7 +120,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -131,7 +131,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -142,7 +142,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -227,7 +227,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -314,7 +314,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
@@ -348,7 +348,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -375,7 +375,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -407,7 +407,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -607,7 +607,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -663,7 +663,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_1024nm.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_1024nm.cue
@@ -111,7 +111,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -121,7 +121,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -132,7 +132,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -143,7 +143,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -228,7 +228,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -316,7 +316,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -350,7 +350,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -377,7 +377,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -409,7 +409,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -625,7 +625,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -687,7 +687,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_512nm.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_512nm.cue
@@ -109,7 +109,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -119,7 +119,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -130,7 +130,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -141,7 +141,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -226,7 +226,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -313,7 +313,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -347,7 +347,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -374,7 +374,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -406,7 +406,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -606,7 +606,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[64, 64, #Z_END - #Z_START], [44, 44, #Z_END - #Z_START]]
@@ -662,7 +662,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_iter1000.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_iter1000.cue
@@ -110,7 +110,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -120,7 +120,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -131,7 +131,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -142,7 +142,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -227,7 +227,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -314,7 +314,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -348,7 +348,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -375,7 +375,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -407,7 +407,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -607,7 +607,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -663,7 +663,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_pair_alignment.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/0_pair_alignment.cue
@@ -106,7 +106,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -116,7 +116,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -127,7 +127,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -138,7 +138,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -223,7 +223,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -311,7 +311,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -345,7 +345,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -372,7 +372,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -404,7 +404,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -620,7 +620,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -682,7 +682,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/1.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/1.cue
@@ -109,7 +109,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -119,7 +119,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -130,7 +130,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -141,7 +141,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -226,7 +226,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -313,7 +313,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -347,7 +347,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -374,7 +374,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -406,7 +406,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -606,7 +606,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -662,7 +662,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/1_1024nm.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/1_1024nm.cue
@@ -111,7 +111,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -121,7 +121,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -132,7 +132,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -143,7 +143,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -228,7 +228,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -316,7 +316,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -350,7 +350,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -377,7 +377,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -409,7 +409,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -625,7 +625,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -687,7 +687,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/1_debug_blend.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/1_debug_blend.cue
@@ -111,7 +111,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -121,7 +121,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -132,7 +132,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -143,7 +143,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -228,7 +228,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -316,7 +316,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -350,7 +350,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -377,7 +377,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -409,7 +409,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -629,7 +629,7 @@
 		"@type":    "lambda"
 		lambda_str: "lambda yo: yo"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -676,7 +676,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/2.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/2.cue
@@ -103,7 +103,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -113,7 +113,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -124,7 +124,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -135,7 +135,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -220,7 +220,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -307,7 +307,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -341,7 +341,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -368,7 +368,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -400,7 +400,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -600,7 +600,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -656,7 +656,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/2_2024nm.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/2_2024nm.cue
@@ -106,7 +106,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -116,7 +116,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -127,7 +127,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -138,7 +138,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -223,7 +223,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -311,7 +311,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -345,7 +345,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -372,7 +372,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -404,7 +404,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -620,7 +620,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 
@@ -682,7 +682,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/3.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/3.cue
@@ -107,7 +107,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -117,7 +117,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -128,7 +128,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -139,7 +139,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -224,7 +224,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -311,7 +311,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -345,7 +345,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -372,7 +372,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -404,7 +404,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -604,7 +604,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           #BBOX
 	processing_chunk_sizes: [[128, 128, #Z_END - #Z_START], [72, 72, #Z_END - #Z_START]]
@@ -660,7 +660,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/debug/0_stuck.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/0_blocks/debug/0_stuck.cue
@@ -46,7 +46,7 @@
 #DOWNSAMPLE_FLOW: {
 	"@type":     "build_subchunkable_apply_flow"
 	bbox:        _
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 4, 1024 * 4, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/1_combine_fields.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/1_combine_fields.cue
@@ -17,7 +17,7 @@
 		"@type": "WarpOperation"
 		mode:    "field"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/1_invert_afield_1024nm.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/1_invert_afield_1024nm.cue
@@ -19,7 +19,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[512, 512, 1], [64, 64, 1]]
 	max_reduction_chunk_sizes: [512, 512, 1]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/1_invert_afields.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/1_invert_afields.cue
@@ -19,7 +19,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[512, 512, 1], [64, 64, 1]]
 	max_reduction_chunk_sizes: [512, 512, 1]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/2_warp.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/2_warp.cue
@@ -15,7 +15,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[#CHUNK, #CHUNK, 1]]
 	processing_crop_pads: [[#CROP_PAD, #CROP_PAD, 0]]
 	//level_intermediaries_dirs: ["file://~/.zutils/tmp", "file://~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/4_downsample.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/4_downsample.cue
@@ -9,7 +9,7 @@
 
 #FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
-	//expand_bbox: true
+	//expand_bbox_processing: true
 	shrink_processing_chunk: true
 	processing_chunk_sizes:  _
 	dst_resolution:          _

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/5_encode.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/5_encode.cue
@@ -104,7 +104,7 @@ import "list"
 		crop_pad: [16, 16, 0]
 		res_change_mult: [int, int, int]
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [int, int, int]
 	processing_chunk_sizes: _
 	processing_crop_pads: [0, 0, 0]

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/6_mask_encs.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/6_mask_encs.cue
@@ -13,7 +13,7 @@
 
 #FLOW_TMPL: {
 	"@type":                "build_subchunkable_apply_flow"
-	expand_bbox:            true
+	expand_bbox_processing:            true
 	processing_chunk_sizes: _
 	dst_resolution:         _
 	fn: {

--- a/specs/sergiy/inference/cns/4_multistage/v0/9_old/\
+++ b/specs/sergiy/inference/cns/4_multistage/v0/9_old/\
@@ -30,7 +30,7 @@
 #INVERT_FLOW: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial", mode: "torchfields"}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024, 1024, 1]]
 	//max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]

--- a/specs/sergiy/inference/cns/4_multistage/v1/0_align_blocks_512nm.cue
+++ b/specs/sergiy/inference/cns/4_multistage/v1/0_align_blocks_512nm.cue
@@ -95,7 +95,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [1024, 1024, 45]
@@ -105,7 +105,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [512, 512, 45]
@@ -116,7 +116,7 @@
 			lr:       0.015
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [256, 256, 45]
@@ -127,7 +127,7 @@
 			lr:       0.03
 		}
 		shrink_processing_chunk: true
-		expand_bbox:             false
+		expand_bbox_processing:             false
 	},
 	#STAGE_TMPL & {
 		dst_resolution: [128, 128, 45]
@@ -212,7 +212,7 @@
 
 	processing_blend_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]
-	expand_bbox:             bool | *true
+	expand_bbox_processing:             bool | *true
 	shrink_processing_chunk: bool | *false
 
 	fn: {
@@ -300,7 +300,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -334,7 +334,7 @@
 #INVERT_FLOW_TMPL: {
 	"@type": "build_subchunkable_apply_flow"
 	fn: {"@type": "invert_field", "@mode": "partial"}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [64, 64, 0]]
@@ -361,7 +361,7 @@
 		"@type":    "BaseEncoder"
 		model_path: #BASE_ENCODER_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 1, 1024 * 1, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -392,7 +392,7 @@
 		"@type":    "MisalignmentDetector"
 		model_path: #MISD_MODEL_PATH
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
@@ -615,7 +615,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 
@@ -679,7 +679,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/cns/coarse_surgery/0_align_pairs.cue
+++ b/specs/sergiy/inference/cns/coarse_surgery/0_align_pairs.cue
@@ -314,7 +314,7 @@
 	}
 	dst_resolution: #STAGES[len(#STAGES)-1].dst_resolution
 	bbox:           #BBOX
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	processing_chunk_sizes: [[512, 512, #Z_END - #Z_START]]
 	processing_crop_pads: [[32, 32, 0]]
 	level_intermediaries_dirs: ["file://~/.zutil/tmp"]

--- a/specs/sergiy/inference/zfish/0_prepare_stack/0_precoarse/9_create_tissue_mask.cue
+++ b/specs/sergiy/inference/zfish/0_prepare_stack/0_precoarse/9_create_tissue_mask.cue
@@ -13,7 +13,7 @@
 
 #CREATE_TISSUE_MASK: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	bbox:        #BBOX
 	fn: {
 		"@type": "apply_mask_fn"
@@ -56,7 +56,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/zfish/1_align/0_stage0/1_relax.cue
+++ b/specs/sergiy/inference/zfish/1_align/0_stage0/1_relax.cue
@@ -89,7 +89,7 @@
 		"@type": "WarpOperation"
 		mode:    _
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]
 	processing_crop_pads: [[0, 0, 0], [256, 256, 0]]
@@ -259,7 +259,7 @@
 	op: {
 		"@type": "AcedRelaxationOp"
 	}
-	expand_bbox:    true
+	expand_bbox_processing:    true
 	dst_resolution: #RELAXATION_RESOLUTION
 	bbox:           _
 
@@ -337,7 +337,7 @@
 
 #DOWNSAMPLE_FLOW_TMPL: {
 	"@type":     "build_subchunkable_apply_flow"
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [1024 * 2, 1024 * 2, 1]]
 	processing_crop_pads: [[0, 0, 0], [0, 0, 0]]
 	level_intermediaries_dirs: [#TMP_PATH, "~/.zutils/tmp"]

--- a/specs/sergiy/inference/zfish/1_align/0_stage0/2_debug_blend.cue
+++ b/specs/sergiy/inference/zfish/1_align/0_stage0/2_debug_blend.cue
@@ -18,7 +18,7 @@
 		"@type":      "lambda"
 		"lambda_str": "lambda src: (src != src).float()"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [512, 512, 30]
 	bbox: #BBOX
 

--- a/specs/sergiy/inference/zfish/1_align/0_stage0/test_mask.cue
+++ b/specs/sergiy/inference/zfish/1_align/0_stage0/test_mask.cue
@@ -70,7 +70,7 @@
 		"@type":      "lambda"
 		"lambda_str": "lambda src: src"
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	dst_resolution: [512, 512, 30]
 	bbox: _
 

--- a/specs/sergiy/inference/zfish/1_align/1_warp_masks.cue
+++ b/specs/sergiy/inference/zfish/1_align/1_warp_masks.cue
@@ -16,7 +16,7 @@
 		mode:                    _
 		translation_granularity: 16
 	}
-	expand_bbox: true
+	expand_bbox_processing: true
 	processing_chunk_sizes: [[1024 * 8, 1024 * 8, 1], [2048, 2048, 1]]
 	processing_crop_pads: [[0, 0, 0], [512, 512, 0]]
 	max_reduction_chunk_sizes: [1024 * 8, 1024 * 8, 1]

--- a/specs/tommy/lee_fly_cns_segmentation_test001/230608_detect_three_image_masks.cue
+++ b/specs/tommy/lee_fly_cns_segmentation_test001/230608_detect_three_image_masks.cue
@@ -32,7 +32,7 @@ target: {
 	processing_crop_pads: [[0, 0, 2]]
 	processing_blend_pads: [[0, 0, 0]]
 
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	fn: {
 		"@type": "detect_consecutive_masks"

--- a/specs/tommy/lee_fly_cns_segmentation_test001/230610_detect_three_resin_masks.cue
+++ b/specs/tommy/lee_fly_cns_segmentation_test001/230610_detect_three_resin_masks.cue
@@ -32,7 +32,7 @@ target: {
 	processing_crop_pads: [[0, 0, 2]]
 	processing_blend_pads: [[0, 0, 0]]
 
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	fn: {
 		"@type": "detect_consecutive_masks"

--- a/specs/tommy/lee_fly_cns_segmentation_test001/230612_copy_affinities.cue
+++ b/specs/tommy/lee_fly_cns_segmentation_test001/230612_copy_affinities.cue
@@ -29,7 +29,7 @@ local_test:      true
 	processing_chunk_sizes: [[144 * 2, 144 * 2, 13]]
 	processing_crop_pads: [[0, 0, 0]]
 	processing_blend_pads: [[0, 0, 0]]
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	fn: {
 		"@type":    "lambda"

--- a/specs/tommy/lee_fly_cns_segmentation_test001/detect_three_image_masks.cue
+++ b/specs/tommy/lee_fly_cns_segmentation_test001/detect_three_image_masks.cue
@@ -34,7 +34,7 @@ target: {
 	processing_crop_pads: [[0, 0, 2]]
 	processing_blend_pads: [[0, 0, 0]]
 
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	// Specification for the operation we're performing
 	fn: {

--- a/specs/tommy/lee_fly_cns_segmentation_test001/upsample_add_one.cue
+++ b/specs/tommy/lee_fly_cns_segmentation_test001/upsample_add_one.cue
@@ -38,7 +38,7 @@ target: {
 
 	// We want to expand the input bbox to be evenly divisible
 	// by chunk size
-	expand_bbox: true
+	expand_bbox_processing: true
 
 	// Specification for the operation we're performing
 	fn: {

--- a/zetta_utils/mazepa_layer_processing/alignment/compute_field_flow.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/compute_field_flow.py
@@ -135,7 +135,7 @@ class ComputeFieldFlowSchema:
     ] = "linear"
     level_intermediaries_dirs: Sequence[str | None] | None = None
     max_reduction_chunk_sizes: Sequence[int] | Sequence[Sequence[int]] | None = None
-    expand_bbox: bool = False
+    expand_bbox_processing: bool = False
     shrink_processing_chunk: bool = False
 
     def flow(
@@ -171,7 +171,7 @@ class ComputeFieldFlowSchema:
             processing_crop_pads=self.processing_crop_pads,
             processing_blend_pads=self.processing_blend_pads,
             processing_blend_modes=self.processing_blend_modes,
-            expand_bbox=self.expand_bbox,
+            expand_bbox_processing=self.expand_bbox_processing,
             shrink_processing_chunk=self.shrink_processing_chunk,
             max_reduction_chunk_sizes=self.max_reduction_chunk_sizes,
             level_intermediaries_dirs=self.level_intermediaries_dirs,

--- a/zetta_utils/mazepa_layer_processing/alignment/compute_field_multistage_flow.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/compute_field_multistage_flow.py
@@ -36,7 +36,7 @@ class ComputeFieldStage:
     ] = "linear"
     level_intermediaries_dirs: Sequence[str | None] | None = None
     max_reduction_chunk_sizes: Sequence[int] | Sequence[Sequence[int]] | None = None
-    expand_bbox: bool = False
+    expand_bbox_processing: bool = False
     shrink_processing_chunk: bool = False
 
     operation: ComputeFieldOperation = attrs.field(init=False)
@@ -181,7 +181,7 @@ class ComputeFieldMultistageFlowSchema:
                 processing_crop_pads=stage.processing_crop_pads,
                 processing_blend_pads=stage.processing_blend_pads,
                 processing_blend_modes=stage.processing_blend_modes,
-                expand_bbox=stage.expand_bbox,
+                expand_bbox_processing=stage.expand_bbox_processing,
                 shrink_processing_chunk=stage.shrink_processing_chunk,
                 max_reduction_chunk_sizes=stage.max_reduction_chunk_sizes,
                 level_intermediaries_dirs=stage.level_intermediaries_dirs,

--- a/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
@@ -259,7 +259,7 @@ def build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg,
                 f"`processing_blend_pads` must be {[0, 0, 0]} in all levels when "
                 "`skip_intermediaries` = True."
             )
-        if any(any(v != 0 for v in pad) for pad in processing_crop_pads_):
+        if any(any(v != 0 for v in pad) for pad in processing_crop_pads_[:-1]):
             raise ValueError(
                 f"`processing_crop_pads` must be {[0, 0, 0]} in all levels except the "
                 "bottom (smallest) when `skip_intermediaries` = True."


### PR DESCRIPTION
3 lines other than spec updates.