### PR TITLE
feat: Import Everything option for python-style specs (experimental)

### DIFF
--- a/scripts/generate_everything_import.py
+++ b/scripts/generate_everything_import.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import os
+import pkgutil
+from types import ModuleType
+
+from zetta_utils import log
+
+logger = log.get_logger("zetta_utils")
+
+
+class NameOverlapError(Exception):
+    """Custom exception for name overlaps in modules."""
+
+
+def get_defined_objects(filepath: str) -> list[str]:
+    with open(filepath, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=filepath)
+        return [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef))
+        ]
+
+
+def handle_name_overlap(
+    module_name: str,
+    filepath: str,
+    name: str,
+    cache: dict[str, ModuleType],
+    package_module: ModuleType,
+) -> list[str]:
+    imports: set[str] = set()
+    seen_objects: dict[int, list[str]] = {}
+    module = cache.get(module_name)
+    if module is None:
+        return list(imports)
+    obj = getattr(module, name, None)
+    if not name.startswith("_") and (callable(obj) or isinstance(obj, type)):
+        obj_address = id(obj)
+        if module_name == package_module.__name__:
+            seen_modules = seen_objects.setdefault(obj_address, [])
+            if len(seen_modules) == 1 and seen_modules[0] == filepath:
+                return list(imports)
+            seen_modules.append(filepath)
+            conflicting_module = seen_modules[0]
+            raise NameOverlapError(
+                f"Name overlap detected: {name}. Defined in {filepath} and {conflicting_module}."
+            )
+        imports.add(f"from {module.__name__} import {name}")
+    return list(imports)
+
+
+def get_all_objects(package: str, root_package: str, module: ModuleType | None = None) -> str:
+    cache: dict[str, ModuleType] = {}
+    package_module = importlib.import_module(package) if module is None else module
+    imports: set[str] = set()
+    if package_module.__file__:
+        package_dir = os.path.dirname(package_module.__file__)
+        for _, module_name, _ in pkgutil.walk_packages(
+            [package_dir], prefix=f"{package_module.__name__}."
+        ):
+            if module_name == "zetta_utils.everything":
+                continue
+            module = cache.setdefault(module_name, importlib.import_module(module_name))
+            if (
+                module.__package__
+                and module.__package__.startswith(root_package)
+                and module.__file__
+            ):
+                filepath = module.__file__
+                defined_objects = get_defined_objects(filepath)
+                for name in dir(module):
+                    if name in defined_objects:
+                        imports.update(
+                            handle_name_overlap(module_name, filepath, name, cache, package_module)
+                        )
+            if hasattr(module, "__path__"):
+                imports.update(get_all_objects(package, root_package, module).split("\n"))
+    return "\n".join(imports)
+
+
+if __name__ == "__main__":
+    logger.info("Generating import statements...")
+    IMPORT_STATEMENTS = get_all_objects("zetta_utils", "zetta_utils")
+    logger.info("Import statements generated successfully.")
+    OUTPUT_FILE = "api.py"
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as file:
+        file.write("# pylint: disable=unused-import\n\n")
+        file.write(IMPORT_STATEMENTS)
+        file.write("set_verbosity(2)")
+        file.write("configure_logger()")

--- a/tests/unit/test_load_all_modules.py
+++ b/tests/unit/test_load_all_modules.py
@@ -3,3 +3,9 @@ import zetta_utils as zu
 
 def test_load_all_modules():
     zu.load_all_modules()  # pylint: disable=protected-access
+
+
+def test_load_apis():
+    # this is how user would do it, but `import *`
+    # is only allowed at top level, thus use exec:
+    exec("from zetta_utils.api.v0 import *")  # pylint: disable=exec-used

--- a/zetta_utils/api/v0.py
+++ b/zetta_utils/api/v0.py
@@ -1,0 +1,460 @@
+# pylint: disable=unused-import
+
+from zetta_utils.alignment.aced_relaxation import (
+    compute_aced_loss_new,
+    get_aced_match_offsets,
+    get_aced_match_offsets_naive,
+    perform_aced_relaxation,
+)
+from zetta_utils.alignment.base_coarsener import BaseCoarsener
+from zetta_utils.alignment.base_encoder import BaseEncoder
+from zetta_utils.alignment.encoding_coarsener import EncodingCoarsener
+from zetta_utils.alignment.field import (
+    gen_biased_perlin_noise_field,
+    get_rigidity_map,
+    get_rigidity_map_zcxy,
+    invert_field,
+    invert_field_opti,
+    percentile,
+    profile_field2d_percentile,
+)
+from zetta_utils.alignment.misalignment_detector import MisalignmentDetector, naive_misd
+from zetta_utils.alignment.online_finetuner import align_with_online_finetuner
+from zetta_utils.augmentations.common import prob_aug
+from zetta_utils.augmentations.tensor import (
+    add_scalar_aug,
+    clamp_values_aug,
+    rand_perlin_2d,
+    rand_perlin_2d_octaves,
+    square_tile_pattern_aug,
+)
+from zetta_utils.builder.build import BuilderPartial, build
+from zetta_utils.builder.built_in_registrations import (
+    efficient_parse_lambda_str,
+    invoke_lambda_str,
+)
+from zetta_utils.builder.registry import (
+    RegistryEntry,
+    get_matching_entry,
+    register,
+    unregister,
+)
+from zetta_utils.cli.main import cli, run, show_registry
+from zetta_utils.cloud_management.execution_tracker import (
+    ExecutionInfoKeys,
+    heartbeat_tracking_ctx_mngr,
+    read_execution_clusters,
+    read_execution_run,
+    record_execution_run,
+    register_execution,
+    update_execution_heartbeat,
+)
+from zetta_utils.cloud_management.resource_allocation.aws_sqs import (
+    delete_queue,
+    get_queues,
+    sqs_queue_ctx_mngr,
+)
+from zetta_utils.cloud_management.resource_allocation.gcloud.iam import (
+    Role,
+    add_role,
+    get_policy,
+    remove_role,
+    set_policy,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.common import (
+    ClusterAuth,
+    ClusterInfo,
+    get_cluster_data,
+    get_mazepa_worker_command,
+    parse_cluster_info,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.configmap import (
+    configmap_ctx_manager,
+    get_configmap,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.cronjob import (
+    CronJobSpecConfig,
+    configure_cronjob,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.deployment import (
+    deployment_ctx_mngr,
+    get_deployment,
+    get_deployment_spec,
+    get_mazepa_worker_deployment,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.eks import (
+    eks_cluster_data,
+    get_eks_token,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.gke import gke_cluster_data
+from zetta_utils.cloud_management.resource_allocation.k8s.job import (
+    follow_job_logs,
+    get_job,
+    get_job_template,
+    job_ctx_manager,
+    wait_for_job_completion,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.pod import get_pod_spec
+from zetta_utils.cloud_management.resource_allocation.k8s.secret import (
+    get_secrets_and_mapping,
+    get_worker_env_vars,
+    secrets_ctx_mngr,
+)
+from zetta_utils.cloud_management.resource_allocation.k8s.service import (
+    get_service,
+    service_ctx_manager,
+)
+from zetta_utils.cloud_management.resource_allocation.resource_tracker import (
+    ExecutionResource,
+    ExecutionResourceKeys,
+    ExecutionResourceTypes,
+    register_execution_resource,
+)
+from zetta_utils.cloud_management.resource_cleanup import cleanup_execution
+from zetta_utils.common.ctx_managers import set_env_ctx_mngr
+from zetta_utils.common.partial import ComparablePartial
+from zetta_utils.common.path import abspath
+from zetta_utils.common.pprint import lrpad, lrpadprint, utcnow_ISO8601
+from zetta_utils.common.signal_handlers import custom_signal_handler_ctx
+from zetta_utils.common.timer import RepeatTimer
+from zetta_utils.common.user_input import (
+    InputTimedOut,
+    get_user_confirmation,
+    get_user_input,
+    timeout_handler,
+)
+from zetta_utils.convnet.architecture.convblock import ConvBlock
+from zetta_utils.convnet.architecture.primitives import (
+    AvgPool2DFlatten,
+    Clamp,
+    Flatten,
+    MaxPool2DFlatten,
+    RescaleValues,
+    SplitTuple,
+    Unflatten,
+    UpConv,
+    View,
+    build_group_norm,
+    sequential_builder,
+    upsample_builder,
+)
+from zetta_utils.convnet.architecture.unet import UNet
+from zetta_utils.convnet.simple_inference_runner import SimpleInferenceRunner
+from zetta_utils.convnet.utils import load_model, load_weights_file, save_model
+from zetta_utils.distributions.common import (
+    Distribution,
+    normal_distr,
+    to_distribution,
+    uniform_distr,
+)
+from zetta_utils.geometry.bbox import BBox3D
+from zetta_utils.geometry.bbox_strider import BBoxStrider
+from zetta_utils.geometry.vec import Vec3D, is_int_vec, is_raw_vec3d
+from zetta_utils.layer.backend_base import Backend
+from zetta_utils.layer.db_layer.backend import DBBackend
+from zetta_utils.layer.db_layer.build import build_db_layer
+from zetta_utils.layer.db_layer.datastore.backend import DatastoreBackend
+from zetta_utils.layer.db_layer.datastore.build import build_datastore_layer
+from zetta_utils.layer.db_layer.index import DBIndex
+from zetta_utils.layer.db_layer.layer import DBLayer, is_rowdata_seq, is_scalar_seq
+from zetta_utils.layer.layer_base import Layer
+from zetta_utils.layer.layer_set.backend import LayerSetBackend
+from zetta_utils.layer.layer_set.build import build_layer_set
+from zetta_utils.layer.layer_set.layer import LayerSet
+from zetta_utils.layer.protocols import LayerWithIndexDataT, LayerWithIndexT
+from zetta_utils.layer.tools_base import (
+    DataProcessor,
+    IndexChunker,
+    IndexProcessor,
+    JointIndexDataProcessor,
+)
+from zetta_utils.layer.volumetric.backend import VolumetricBackend
+from zetta_utils.layer.volumetric.build import build_volumetric_layer
+from zetta_utils.layer.volumetric.cloudvol.backend import CVBackend
+from zetta_utils.layer.volumetric.cloudvol.build import build_cv_layer
+from zetta_utils.layer.volumetric.constant.backend import ConstantVolumetricBackend
+from zetta_utils.layer.volumetric.constant.build import build_constant_volumetric_layer
+from zetta_utils.layer.volumetric.frontend import VolumetricFrontend
+from zetta_utils.layer.volumetric.index import VolumetricIndex
+from zetta_utils.layer.volumetric.layer import VolumetricLayer
+from zetta_utils.layer.volumetric.layer_set.backend import VolumetricSetBackend
+from zetta_utils.layer.volumetric.layer_set.build import build_volumetric_layer_set
+from zetta_utils.layer.volumetric.layer_set.layer import VolumetricLayerSet
+from zetta_utils.layer.volumetric.precomputed.precomputed import (
+    PrecomputedInfoSpec,
+    get_info,
+)
+from zetta_utils.layer.volumetric.protocols import VolumetricBasedLayerProtocol
+from zetta_utils.layer.volumetric.tensorstore.backend import TSBackend
+from zetta_utils.layer.volumetric.tensorstore.build import build_ts_layer
+from zetta_utils.layer.volumetric.tools import (
+    DataResolutionInterpolator,
+    InvertProcessor,
+    VolumetricIndexChunker,
+    VolumetricIndexTranslator,
+    translate_volumetric_index,
+)
+from zetta_utils.log import (
+    InjectingFilter,
+    add_supress_traceback_module,
+    configure_logger,
+    get_logger,
+    get_time_str,
+    logging_tag_ctx,
+    set_logging_tag,
+    set_verbosity,
+    update_traceback,
+)
+from zetta_utils.mazepa.autoexecute_task_queue import AutoexecuteTaskQueue
+from zetta_utils.mazepa.dryrun import dryrun_for_task_ids, get_expected_operation_counts
+from zetta_utils.mazepa.exceptions import (
+    MazepaCancel,
+    MazepaException,
+    MazepaExecutionFailure,
+    MazepaStop,
+    MazepaTimeoutError,
+)
+from zetta_utils.mazepa.execution import (
+    Executor,
+    backup_completed_tasks,
+    execute,
+    submit_ready_tasks,
+)
+from zetta_utils.mazepa.execution_checkpoint import (
+    read_execution_checkpoint,
+    record_execution_checkpoint,
+)
+from zetta_utils.mazepa.execution_state import (
+    ExecutionState,
+    InMemoryExecutionState,
+    ProgressReport,
+)
+from zetta_utils.mazepa.flows import (
+    Dependency,
+    Flow,
+    FlowSchema,
+    RawFlowSchemaCls,
+    concurrent_flow,
+    flow_schema,
+    flow_schema_cls,
+    sequential_flow,
+)
+from zetta_utils.mazepa.id_generation import (
+    generate_invocation_id,
+    get_literal_id_fn,
+    get_unique_id,
+)
+from zetta_utils.mazepa.progress_tracker import (
+    ProgressUpdateFN,
+    get_confirm_sigint_fn,
+    progress_ctx_mngr,
+)
+from zetta_utils.mazepa.task_outcome import OutcomeReport, TaskOutcome, TaskStatus
+from zetta_utils.mazepa.task_router import TaskRouter
+from zetta_utils.mazepa.tasks import (
+    RawTaskableOperationCls,
+    Task,
+    TaskableOperation,
+    TaskUpkeepSettings,
+    taskable_operation,
+    taskable_operation_cls,
+)
+from zetta_utils.mazepa.transient_errors import (
+    ExplicitTransientError,
+    TransientErrorCondition,
+)
+from zetta_utils.mazepa.worker import AcceptAllTasks, process_task_message, run_worker
+from zetta_utils.mazepa_addons.configurations.execute_on_gcp_with_sqs import (
+    execute_on_gcp_with_sqs,
+    get_gcp_with_sqs_config,
+)
+from zetta_utils.mazepa_addons.misc import test_gcs_access
+from zetta_utils.mazepa_layer_processing.alignment.aced_relaxation_flow import (
+    AcedMatchOffsetOp,
+    AcedRelaxationOp,
+    build_aced_relaxation_flow,
+    build_get_match_offsets_naive_flow,
+)
+from zetta_utils.mazepa_layer_processing.alignment.annotated_section_copy import (
+    AnnotatedSectionCopyFlowSchema,
+    build_annotated_section_copy_flow,
+)
+from zetta_utils.mazepa_layer_processing.alignment.common import (
+    translation_adjusted_download,
+)
+from zetta_utils.mazepa_layer_processing.alignment.compute_alignment_quality import (
+    compute_alignment_quality,
+    compute_misalignment_stats,
+)
+from zetta_utils.mazepa_layer_processing.alignment.compute_field_flow import (
+    ComputeFieldFlowSchema,
+    ComputeFieldFn,
+    ComputeFieldOperation,
+)
+from zetta_utils.mazepa_layer_processing.alignment.compute_field_multistage_flow import (
+    ComputeFieldMultistageFlowSchema,
+    ComputeFieldStage,
+    build_compute_field_multistage_flow,
+)
+from zetta_utils.mazepa_layer_processing.alignment.warp_operation import WarpOperation
+from zetta_utils.mazepa_layer_processing.common.apply_mask_fn import apply_mask_fn
+from zetta_utils.mazepa_layer_processing.common.callable_operation import (
+    CallableOperation,
+    build_chunked_callable_flow_schema,
+)
+from zetta_utils.mazepa_layer_processing.common.chunked_apply_flow import (
+    ChunkedApplyFlowSchema,
+    build_chunked_apply_flow,
+)
+from zetta_utils.mazepa_layer_processing.common.interpolate_flow import (
+    build_interpolate_flow,
+    make_interpolate_operation,
+)
+from zetta_utils.mazepa_layer_processing.common.subchunkable_apply_flow import (
+    DelegatedSubchunkedOperation,
+    build_subchunkable_apply_flow,
+)
+from zetta_utils.mazepa_layer_processing.common.volumetric_apply_flow import (
+    Copy,
+    ReduceByWeightedSum,
+    VolumetricApplyFlowSchema,
+    clear_cache,
+    delete_if_local,
+    get_blending_weights,
+    get_weight_template,
+    set_allow_cache,
+)
+from zetta_utils.mazepa_layer_processing.common.volumetric_callable_operation import (
+    VolumetricCallableOperation,
+    build_chunked_volumetric_callable_flow_schema,
+)
+from zetta_utils.mazepa_layer_processing.common.write_fn import write_fn
+from zetta_utils.mazepa_layer_processing.operation_protocols import (
+    ChunkableOpProtocol,
+    ComputeFieldOpProtocol,
+    MultiresOpProtocol,
+    VolumetricOpProtocol,
+)
+from zetta_utils.mazepa_layer_processing.segmentation.masks.affinities import (
+    AdjustAffinitiesOp,
+    adjust_affinities_across_mask_boundary,
+    adjust_thresholded_affinities_in_mask,
+)
+from zetta_utils.mazepa_layer_processing.segmentation.masks.masks import (
+    detect_consecutive_masks,
+)
+from zetta_utils.message_queues.base import (
+    MessageQueue,
+    PullMessageQueue,
+    PushMessageQueue,
+    ReceivedMessage,
+)
+from zetta_utils.message_queues.serialization import deserialize, serialize, test
+from zetta_utils.message_queues.sqs.queue import SQSQueue, TQTask
+from zetta_utils.message_queues.sqs.utils import (
+    SQSReceivedMsg,
+    change_message_visibility,
+    delete_msg_by_receipt_handle,
+    get_queue_url,
+    get_sqs_client,
+    receive_msgs,
+)
+from zetta_utils.ng.link_builder import make_ng_link
+from zetta_utils.parsing.cue import load, load_local, loads
+from zetta_utils.parsing.ngl_state import (
+    AnnotationKeys,
+    DefaultLayerValues,
+    NglLayerKeys,
+    read_remote_annotations,
+    write_remote_annotations,
+)
+from zetta_utils.segmentation.inference import run_affinities_inference_onnx
+from zetta_utils.tensor_mapping.tensor_mapping import TensorMapping
+from zetta_utils.tensor_ops.common import (
+    add,
+    compare,
+    crop,
+    divide,
+    int_divide,
+    interpolate,
+    multiply,
+    power,
+    rearrange,
+    reduce,
+    repeat,
+    squeeze,
+    squeeze_to,
+    unsqueeze,
+    unsqueeze_to,
+)
+from zetta_utils.tensor_ops.convert import astype, to_float32, to_np, to_torch, to_uint8
+from zetta_utils.tensor_ops.mask import (
+    TensorOp,
+    filter_cc,
+    kornia_closing,
+    kornia_dilation,
+    kornia_erosion,
+    kornia_opening,
+    skip_on_empty_data,
+)
+from zetta_utils.tensor_ops.transform import get_affine_field
+from zetta_utils.training.datasets.joint_dataset import JointDataset
+from zetta_utils.training.datasets.layer_dataset import LayerDataset
+from zetta_utils.training.datasets.sample_indexers.base import SampleIndexer
+from zetta_utils.training.datasets.sample_indexers.chain_indexer import ChainIndexer
+from zetta_utils.training.datasets.sample_indexers.loop_indexer import LoopIndexer
+from zetta_utils.training.datasets.sample_indexers.random_indexer import RandomIndexer
+from zetta_utils.training.datasets.sample_indexers.volumetric_ngl_indexer import (
+    VolumetricNGLIndexer,
+)
+from zetta_utils.training.datasets.sample_indexers.volumetric_strided_indexer import (
+    VolumetricStridedIndexer,
+)
+from zetta_utils.training.lightning.regimes.alignment.base_encoder import (
+    BaseEncoderRegime,
+)
+from zetta_utils.training.lightning.regimes.alignment.encoding_coarsener import (
+    EncodingCoarsenerRegime,
+)
+from zetta_utils.training.lightning.regimes.alignment.encoding_coarsener_gen_x1 import (
+    EncodingCoarsenerGenX1Regime,
+)
+from zetta_utils.training.lightning.regimes.alignment.encoding_coarsener_highres import (
+    EncodingCoarsenerHighRes,
+    center_crop_norm,
+    warp_by_px,
+)
+from zetta_utils.training.lightning.regimes.alignment.minima_encoder import (
+    MinimaEncoderRegime,
+)
+from zetta_utils.training.lightning.regimes.alignment.misalignment_detector import (
+    MisalignmentDetectorRegime,
+)
+from zetta_utils.training.lightning.regimes.alignment.misalignment_detector_aced import (
+    MisalignmentDetectorAcedRegime,
+)
+from zetta_utils.training.lightning.regimes.common import is_2d_image, log_results
+from zetta_utils.training.lightning.regimes.naive_supervised import (
+    NaiveSupervisedRegime,
+)
+from zetta_utils.training.lightning.regimes.noop import NoOpRegime
+from zetta_utils.training.lightning.train import lightning_train, lightning_train_remote
+from zetta_utils.training.lightning.trainers.default import (
+    ConfigureTraceCallback,
+    ZettaDefaultTrainer,
+    build_default_trainer,
+    get_checkpointing_callbacks,
+    get_progress_bar_callbacks,
+    trace_and_save_model,
+)
+from zetta_utils.typing import (
+    ArithmeticOperand,
+    check_type,
+    ensure_seq_of_seq,
+    get_orig_class,
+)
+from zetta_utils.viz.rendering import Renderer, get_img_from_fig, render_fld, render_img
+from zetta_utils.viz.widgets import entry_loader, visualize_list
+
+set_verbosity(2)
+configure_logger()

--- a/zetta_utils/cloud_management/resource_allocation/aws_sqs.py
+++ b/zetta_utils/cloud_management/resource_allocation/aws_sqs.py
@@ -26,17 +26,10 @@ def sqs_queue_ctx_mngr(execution_id: str, name: str):
         queue.delete()
 
 
-def get_queue_url(name: str) -> str:
-    """Get the url of an existing queue."""
-    sqs = boto3.client("sqs")
-    queue_url = sqs.get_queue_url(QueueName=name)["QueueUrl"]
-    return queue_url
-
-
 def delete_queue(name: str):
     """Delete queue with given url."""
     sqs = boto3.client("sqs")
-    queue_url = get_queue_url(name)
+    queue_url = sqs.get_queue_url(QueueName=name)["QueueUrl"]
     sqs.delete_queue(QueueUrl=queue_url)
 
 

--- a/zetta_utils/mazepa_addons/configurations/execute_on_gcp_with_sqs.py
+++ b/zetta_utils/mazepa_addons/configurations/execute_on_gcp_with_sqs.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import copy
 import os
-from contextlib import AbstractContextManager, ExitStack, contextmanager
+from contextlib import AbstractContextManager, ExitStack
 from typing import Dict, Final, Iterable, Optional, Union
 
 from zetta_utils import builder, log, mazepa
 from zetta_utils.cloud_management import execution_tracker, resource_allocation
-from zetta_utils.common import RepeatTimer
 from zetta_utils.mazepa.task_outcome import OutcomeReport
 from zetta_utils.mazepa.tasks import Task
 from zetta_utils.message_queues import sqs  # pylint: disable=unused-import
@@ -105,21 +104,6 @@ def get_gcp_with_sqs_config(
     return task_queue, outcome_queue, ctx_managers
 
 
-@contextmanager
-def heartbeat_tracking_ctx_mngr(execution_id, heartbeat_interval=30):
-    def _send_heartbeat():
-        execution_tracker.update_execution_heartbeat(execution_id)
-
-    heart = RepeatTimer(heartbeat_interval, _send_heartbeat)
-    heart.start()
-    try:
-        yield
-    except Exception as e:
-        raise e from None
-    finally:
-        heart.cancel()
-
-
 @builder.register("mazepa.execute_on_gcp_with_sqs")
 def execute_on_gcp_with_sqs(  # pylint: disable=too-many-locals
     target: Union[mazepa.Flow, mazepa.ExecutionState],
@@ -184,7 +168,7 @@ def execute_on_gcp_with_sqs(  # pylint: disable=too-many-locals
         )
 
     with ExitStack() as stack:
-        stack.enter_context(heartbeat_tracking_ctx_mngr(execution_id))
+        stack.enter_context(execution_tracker.heartbeat_tracking_ctx_mngr(execution_id))
         for mngr in ctx_managers:
             stack.enter_context(mngr)
         assert (outcome_queue is None and task_queue is None) or (


### PR DESCRIPTION
Python spec files, which are still in the testing phase, can now pull in all primitives from the entire repo with:

```python
from zetta_utils.everything import *
```

The `everything.py` file is autogenerated by looking at the repo's source code, as doing it manually would be too hard to maintain. The generator ensures there aren’t any naming conflicts. If it finds any, it'll throw an error. If python specs get more popular, we might want to add a check for duplicates in our CI.

`everything.py` doesn't include anything from `convnet.architecture.deprecated`, as we don't have any old python specs to deal with. Python specs don’t have the versioning capabilities that the builder does, so we need to think of something different. One idea is to have different versioned `everything` files. For example, `everything_v0.py` could import the old UNet, and `everything_v1.py` the new one. The spec version would be clear from the get-go, as in `from zetta_utils.everything_v0 import *`. If we like this idea, maybe I should rename the current `everything.py` to `everything_v0.py` to start with clear versioning.

This PR also has a couple more tweaks: importing from zetta now sets up the logger automatically, and I've done a bit of tidying to avoid naming issues.