### PR TITLE
Rounding Issues... Round 2

### DIFF
--- a/tests/unit/geometry/test_bbox.py
+++ b/tests/unit/geometry/test_bbox.py
@@ -365,11 +365,19 @@ def test_cropped_exc(bbox: BBox3D, crop, resolution: Vec3D, expected_exc):
             "expand",
             BBox3D(bounds=((-1, 1), (-3, 3), (-5, 7))),
         ],
+        [
+            BBox3D(bounds=((-1, 1), (-3, 3.1), (-5, 7))),
+            (0, 0.0, 0.0),
+            (0.1, 0.6 / 3.0, 0.1 + 0.2),
+            "expand",
+            BBox3D(bounds=((-1.0, 1.0), (-3.0, 3.2), (-5.1, 7.2))),
+        ],
     ],
 )
 def test_snapped(bbox: BBox3D, grid_offset, grid_size, mode, expected: BBox3D):
     result = bbox.snapped(grid_offset=grid_offset, grid_size=grid_size, mode=mode)
-    assert result == expected
+    assert result.start.allclose(expected.start)
+    assert result.end.allclose(expected.end)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/geometry/test_bbox_strider.py
+++ b/tests/unit/geometry/test_bbox_strider.py
@@ -174,6 +174,39 @@ def test_bbox_strider_get_all_chunks_parallel(mocker):
             None,
             6,
         ],
+        [
+            Vec3D(0, -1, 0),
+            Vec3D(2, 3, 4),
+            Vec3D(0.1, 0.6/3.0, 0.1+0.2),
+            IntVec3D(2, 2, 2),
+            IntVec3D(2, 2, 2),
+            None,
+            "exact",
+            None,
+            4,
+        ],
+        [
+            Vec3D(0, -1, 0),
+            Vec3D(2, 3, 4),
+            Vec3D(0.1, 0.6/3.0, 0.1+0.2),
+            IntVec3D(2, 2, 2),
+            IntVec3D(2, 2, 2),
+            None,
+            "expand",
+            None,
+            4,
+        ],
+        [
+            Vec3D(0, -1, 0),
+            Vec3D(2, 3, 4),
+            Vec3D(0.1, 0.6/3.0, 0.1+0.2),
+            IntVec3D(2, 2, 2),
+            IntVec3D(2, 2, 2),
+            None,
+            "shrink",
+            None,
+            4,
+        ],
     ],
 )
 def test_bbox_strider_len(
@@ -312,6 +345,42 @@ def test_bbox_strider_len(
             5,
             BBox3D.from_slices((slice(1, 4), slice(1, 4), slice(3, 6))),
         ],
+        [
+            Vec3D(0, -1, 0),
+            Vec3D(2, 3, 3),
+            Vec3D(0.1, 0.6/3.0, 0.1+0.2),
+            IntVec3D(2, 2, 1),
+            IntVec3D(2, 2, 1),
+            Vec3D(0, 0.2, 0.3),
+            "exact",
+            None,
+            3,
+            BBox3D.from_slices((slice(0, 0.2), slice(0.2, 0.6), slice(0.3, 0.6)))
+        ],
+        [
+            Vec3D(0, -1, 0),
+            Vec3D(2, 3, 3),
+            Vec3D(0.1, 0.6/3.0, 0.1+0.2),
+            IntVec3D(2, 2, 1),
+            IntVec3D(2, 2, 1),
+            Vec3D(0, 0.2, 0.3),
+            "shrink",
+            None,
+            3,
+            BBox3D.from_slices((slice(0, 0.2), slice(0.2, 0.6), slice(0.3, 0.6)))
+        ],
+        [
+            Vec3D(0, -1, 0),
+            Vec3D(2, 3, 3),
+            Vec3D(0.1, 0.6/3.0, 0.1+0.2),
+            IntVec3D(2, 2, 1),
+            IntVec3D(2, 2, 1),
+            Vec3D(0, 0.2, 0.3),
+            "expand",
+            None,
+            3,
+            BBox3D.from_slices((slice(0, 0.2), slice(0.2, 0.6), slice(0.3, 0.6)))
+        ],
     ],
 )
 def test_bbox_strider_get_nth_res(
@@ -337,7 +406,8 @@ def test_bbox_strider_get_nth_res(
         mode=mode,
         max_superchunk_size=max_superchunk_size,
     )
-    assert strider.get_nth_chunk_bbox(idx) == expected
+    bbox = strider.get_nth_chunk_bbox(idx)
+    assert bbox.start.allclose(expected.start) and bbox.end.allclose(expected.end)
 
 
 def test_bbox_strider_exc(mocker):

--- a/tests/unit/geometry/test_vec.py
+++ b/tests/unit/geometry/test_vec.py
@@ -7,7 +7,7 @@ import pytest
 import typeguard
 
 from zetta_utils import builder
-from zetta_utils.geometry.vec import Vec3D, allclose, isclose
+from zetta_utils.geometry.vec import VEC3D_PRECISION, Vec3D, allclose, isclose
 
 some_float = 42.42
 some_int = 42
@@ -181,7 +181,7 @@ def test_abs():
 
 
 def test_round():
-    assert round(vec3d_fp1, 8) == vec3d_fp2
+    assert round(vec3d_fp1, VEC3D_PRECISION) == vec3d_fp2
 
 
 def test_floor():

--- a/tests/unit/geometry/test_vec.py
+++ b/tests/unit/geometry/test_vec.py
@@ -1,12 +1,13 @@
 # pylint: disable=all
 import typing
+from math import ceil, floor, trunc
 
 import numpy as np
 import pytest
 import typeguard
 
 from zetta_utils import builder
-from zetta_utils.geometry.vec import Vec3D
+from zetta_utils.geometry.vec import Vec3D, allclose, isclose
 
 some_float = 42.42
 some_int = 42
@@ -174,8 +175,25 @@ def test_neg():
     assert vec3d == -vec3d_neg
 
 
+def test_abs():
+    assert abs(vec3d_neg) == vec3d
+    assert abs(vec3d) == vec3d
+
+
 def test_round():
     assert round(vec3d_fp1, 8) == vec3d_fp2
+
+
+def test_floor():
+    assert floor(Vec3D(0.5, -2.5, 3.0)) == Vec3D(0, -3, 3)
+
+
+def test_trunc():
+    assert trunc(Vec3D(0.5, -2.5, 3.0)) == Vec3D(0, -2, 3)
+
+
+def test_ceil():
+    assert ceil(Vec3D(0.5, -2.5, 3.0)) == Vec3D(1, -2, 3)
 
 
 @pytest.mark.parametrize(
@@ -352,7 +370,11 @@ def test_subtyping() -> None:
         some_int * intvec3d,
         some_int // intvec3d,
         some_int % intvec3d,
+        abs(intvec3d),
         round(intvec3d),
+        floor(intvec3d),
+        trunc(intvec3d),
+        ceil(intvec3d),
     ]:
 
         test_inference_return_int3d(x)
@@ -409,6 +431,17 @@ def test_subtyping() -> None:
         some_float // intvec3d,
         some_float / intvec3d,
         some_float % intvec3d,
+        abs(vec3d),
         round(vec3d),
     ]:
         test_inference_return_vec3d(y)
+
+
+def test_isclose():
+    assert isclose(vec3d_fp1, vec3d_fp2) == (True, True, True)
+    assert isclose(vec3d_fp1, vec3d_fp2, abs_tol=0.0, rel_tol=0.0) == (True, False, False)
+
+
+def test_allclose():
+    assert allclose(vec3d_fp1, vec3d_fp2) == True
+    assert allclose(vec3d_fp1, vec3d_fp2, abs_tol=0.0, rel_tol=0.0) == False

--- a/zetta_utils/geometry/bbox.py
+++ b/zetta_utils/geometry/bbox.py
@@ -8,6 +8,7 @@ import attrs
 from typeguard import typechecked
 
 from zetta_utils import builder
+from zetta_utils.geometry.vec import VEC3D_PRECISION
 
 from . import Vec3D
 
@@ -131,8 +132,8 @@ class BBox3D:
         else:
             dim_res = resolution[dim]
 
-        dim_range_start_raw = round(self.bounds[dim][0] / dim_res, 10)
-        dim_range_end_raw = round(self.bounds[dim][1] / dim_res, 10)
+        dim_range_start_raw = round(self.bounds[dim][0] / dim_res, VEC3D_PRECISION)
+        dim_range_end_raw = round(self.bounds[dim][1] / dim_res, VEC3D_PRECISION)
 
         if not round_to_int:
             return slice(dim_range_start_raw, dim_range_end_raw)
@@ -387,21 +388,21 @@ class BBox3D:
 
         if mode == "shrink":
             start_final = tuple(
-                floor(round((b[0] - o) / s + 1, 10) - EPS) * s + o
+                floor(round((b[0] - o) / s + 1, VEC3D_PRECISION) - EPS) * s + o
                 for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
             end_final = tuple(
-                floor(round((b[1] - o) / s, 10)) * s + o
+                floor(round((b[1] - o) / s, VEC3D_PRECISION)) * s + o
                 for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
         else:
             assert mode == "expand", "Typechecking error"
             start_final = tuple(
-                floor(round((b[0] - o) / s, 10)) * s + o
+                floor(round((b[0] - o) / s, VEC3D_PRECISION)) * s + o
                 for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
             end_final = tuple(
-                floor(round((b[1] - o) / s + 1, 10) - EPS) * s + o
+                floor(round((b[1] - o) / s + 1, VEC3D_PRECISION) - EPS) * s + o
                 for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
         return BBox3D.from_coords(

--- a/zetta_utils/geometry/bbox.py
+++ b/zetta_utils/geometry/bbox.py
@@ -387,19 +387,21 @@ class BBox3D:
 
         if mode == "shrink":
             start_final = tuple(
-                ((b[0] - o - EPS) // s + 1) * s + o
+                floor(round((b[0] - o) / s + 1, 10) - EPS) * s + o
                 for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
             end_final = tuple(
-                (b[1] - o) // s * s + o for b, o, s in zip(self.bounds, grid_offset, grid_size)
+                floor(round((b[1] - o) / s, 10)) * s + o
+                for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
         else:
             assert mode == "expand", "Typechecking error"
             start_final = tuple(
-                (b[0] - o) // s * s + o for b, o, s in zip(self.bounds, grid_offset, grid_size)
+                floor(round((b[0] - o) / s, 10)) * s + o
+                for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
             end_final = tuple(
-                ((b[1] - o - EPS) // s + 1) * s + o
+                floor(round((b[1] - o) / s + 1, 10) - EPS) * s + o
                 for b, o, s in zip(self.bounds, grid_offset, grid_size)
             )
         return BBox3D.from_coords(

--- a/zetta_utils/geometry/bbox_strider.py
+++ b/zetta_utils/geometry/bbox_strider.py
@@ -9,6 +9,7 @@ import attrs
 from typeguard import typechecked
 
 from zetta_utils import builder, log
+from zetta_utils.geometry.vec import VEC3D_PRECISION
 
 from . import Vec3D
 from .bbox import BBox3D
@@ -110,11 +111,11 @@ class BBoxStrider:
                 )
             )
         )
-        step_limits = floor(round(step_limits_snapped, 10))
+        step_limits = floor(round(step_limits_snapped, VEC3D_PRECISION))
         bbox_start_diff = bbox_snapped.start - self.bbox.start
         bbox_end_diff = self.bbox.end - bbox_snapped.end
-        step_start_partial = tuple(round(e, 10) > 0 for e in bbox_start_diff)
-        step_end_partial = tuple(round(e, 10) > 0 for e in bbox_end_diff)
+        step_start_partial = tuple(round(e, VEC3D_PRECISION) > 0 for e in bbox_start_diff)
+        step_end_partial = tuple(round(e, VEC3D_PRECISION) > 0 for e in bbox_end_diff)
         step_limits += Vec3D[int](*(int(e) for e in step_start_partial))
         step_limits += Vec3D[int](*(int(e) for e in step_end_partial))
         logger.info(
@@ -176,7 +177,7 @@ class BBoxStrider:
             )
         )
         if self.mode == "shrink":
-            step_limits = floor(round(step_limits_snapped, 10))
+            step_limits = floor(round(step_limits_snapped, VEC3D_PRECISION))
             if not step_limits_raw.allclose(step_limits):
                 rounded_bbox_bounds = tuple(
                     (
@@ -196,7 +197,7 @@ class BBoxStrider:
                     f" {self.chunk_size_in_unit}{self.bbox.unit}."
                 )
         if self.mode == "expand":
-            step_limits = ceil(round(step_limits_snapped, 10))
+            step_limits = ceil(round(step_limits_snapped, VEC3D_PRECISION))
             if not step_limits_raw.allclose(step_limits):
                 rounded_bbox_bounds = tuple(
                     (

--- a/zetta_utils/geometry/vec.py
+++ b/zetta_utils/geometry/vec.py
@@ -15,6 +15,8 @@ BuiltinFloat = float
 
 T = TypeVar("T", bound=float)
 
+VEC3D_PRECISION = 10
+
 
 @attrs.frozen(init=False)
 @typechecked

--- a/zetta_utils/geometry/vec.py
+++ b/zetta_utils/geometry/vec.py
@@ -1,6 +1,7 @@
 """Basic type definitions used for type annotations."""
 from __future__ import annotations
 
+import math
 from collections import abc
 from typing import Any, Sequence, Tuple, TypeVar, Union, overload
 
@@ -75,6 +76,35 @@ class Vec3D(abc.Sequence[T]):
     def __ge__(self, other) -> bool:
         return all(s >= o for (s, o) in zip(self.vec, other.vec))
 
+    def isclose(
+        self,
+        other: Vec3D | BuiltinFloat | BuiltinInt,
+        *,
+        rel_tol: BuiltinFloat = 1e-05,
+        abs_tol: BuiltinFloat = 1e-08,
+    ) -> Tuple[bool, bool, bool]:
+        if isinstance(other, Vec3D):
+            return (
+                math.isclose(self.x, other.x, rel_tol=rel_tol, abs_tol=abs_tol),
+                math.isclose(self.y, other.y, rel_tol=rel_tol, abs_tol=abs_tol),
+                math.isclose(self.z, other.z, rel_tol=rel_tol, abs_tol=abs_tol),
+            )
+        else:
+            return (
+                math.isclose(self.x, other, rel_tol=rel_tol, abs_tol=abs_tol),
+                math.isclose(self.y, other, rel_tol=rel_tol, abs_tol=abs_tol),
+                math.isclose(self.z, other, rel_tol=rel_tol, abs_tol=abs_tol),
+            )
+
+    def allclose(
+        self,
+        other: Vec3D | BuiltinFloat | BuiltinInt,
+        *,
+        rel_tol: BuiltinFloat = 1e-05,
+        abs_tol: BuiltinFloat = 1e-08,
+    ) -> bool:
+        return all(self.isclose(other, rel_tol=rel_tol, abs_tol=abs_tol))
+
     def __repr__(self) -> str:
         return f"Vec3D({', '.join(str(e) for e in self)})"
 
@@ -90,8 +120,20 @@ class Vec3D(abc.Sequence[T]):
     def __neg__(self) -> Vec3D[T]:
         return Vec3D[T](*(-e for e in self))
 
-    def __round__(self, ndigits=0):
+    def __abs__(self) -> Vec3D[T]:
+        return Vec3D[T](*(abs(e) for e in self))
+
+    def __round__(self, ndigits: int = 0) -> Vec3D[T]:
         return Vec3D[T](*(round(e, ndigits) for e in self))
+
+    def __floor__(self) -> Vec3D[BuiltinInt]:
+        return Vec3D[BuiltinInt](*(math.floor(e) for e in self))
+
+    def __ceil__(self) -> Vec3D[BuiltinInt]:
+        return Vec3D[BuiltinInt](*(math.ceil(e) for e in self))
+
+    def __trunc__(self) -> Vec3D[BuiltinInt]:
+        return Vec3D[BuiltinInt](*(math.trunc(e) for e in self))
 
     @overload
     def __add__(self, other: Union[Vec3D[BuiltinInt], BuiltinInt]) -> Vec3D[T]:
@@ -253,6 +295,28 @@ class Vec3D(abc.Sequence[T]):
 
     def pformat(self) -> str:  # pragma: no cover
         return str(tuple(self))
+
+
+@typechecked
+def isclose(
+    a: Vec3D,
+    b: Vec3D | BuiltinFloat | BuiltinInt,
+    *,
+    rel_tol: BuiltinFloat = 1e-05,
+    abs_tol: BuiltinFloat = 1e-08,
+) -> Tuple[bool, bool, bool]:
+    return a.isclose(b, rel_tol=rel_tol, abs_tol=abs_tol)
+
+
+@typechecked
+def allclose(
+    a: Vec3D,
+    b: Vec3D | BuiltinFloat | BuiltinInt,
+    *,
+    rel_tol: BuiltinFloat = 1e-05,
+    abs_tol: BuiltinFloat = 1e-08,
+) -> bool:
+    return a.allclose(b, rel_tol=rel_tol, abs_tol=abs_tol)
 
 
 @typechecked

--- a/zetta_utils/layer/volumetric/tools.py
+++ b/zetta_utils/layer/volumetric/tools.py
@@ -115,7 +115,7 @@ class VolumetricIndexChunker(IndexChunker[VolumetricIndex]):
     def __call__(
         self,
         idx: VolumetricIndex,
-        stride_start_offset_in_unit: Optional[Vec3D[int]] = None,
+        stride_start_offset_in_unit: Optional[Vec3D] = None,
         mode: Literal["shrink", "expand", "exact"] = "expand",
     ) -> List[VolumetricIndex]:
 
@@ -135,7 +135,7 @@ class VolumetricIndexChunker(IndexChunker[VolumetricIndex]):
     def get_shape(
         self,
         idx: VolumetricIndex,
-        stride_start_offset_in_unit: Optional[Vec3D[int]] = None,
+        stride_start_offset_in_unit: Optional[Vec3D] = None,
         mode: Literal["shrink", "expand", "exact"] = "expand",
     ) -> Vec3D[int]:  # pragma: no cover
 
@@ -144,7 +144,7 @@ class VolumetricIndexChunker(IndexChunker[VolumetricIndex]):
     def _get_bbox_strider(
         self,
         idx: VolumetricIndex,
-        stride_start_offset_in_unit: Optional[Vec3D[int]] = None,
+        stride_start_offset_in_unit: Optional[Vec3D] = None,
         mode: Literal["shrink", "expand", "exact"] = "expand",
     ) -> BBoxStrider:
 
@@ -154,11 +154,11 @@ class VolumetricIndexChunker(IndexChunker[VolumetricIndex]):
             chunk_resolution = self.resolution
 
         if stride_start_offset_in_unit is None:
-            stride_start_offset_to_use = (idx.bbox.start + self.offset * chunk_resolution).int()
+            stride_start_offset_to_use = idx.bbox.start + self.offset * chunk_resolution
         else:
             stride_start_offset_to_use = (
                 stride_start_offset_in_unit + self.offset * chunk_resolution
-            ).int()
+            )
 
         if self.stride is None:
             stride = self.chunk_size


### PR DESCRIPTION
Resolves most of the floating point comparison issues: there are the obvious comparisons (`==`, etc.), for which you can now use `allclose`, but `ceil` and `floor` were more frequently cause for trouble in our code.

Typical example is `floor(0.6/0.2) -> 2`. Resolving this for now with `floor(round(0.6/0.2, 10))`, but it does look a bit ugly...