### PR TITLE
hotfix: unannotate variable, bump typeguard and mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ urls = {Homepage = "https://github.com/zettaai/zetta_utils"}
 requires-python = ">3.8,<3.11"
 dependencies = [
     "attrs >= 21.3",
-    "typeguard",
-    "typeguard @ git+https://github.com/agronholm/typeguard.git@f377be389765ed0db104b41d78fce3c45e72e149",
+    "typeguard == 4.1.0",
     "cachetools >= 5.2.0",
     "fsspec >= 2022.8.2",
     "rich >= 12.6.0",
@@ -139,7 +138,7 @@ test = [
     "click == 8.0.1", # for black to work
     "pydocstyle == 6.1.1",
     "flake8 == 4.0.1",
-    "mypy == 1.4",
+    "mypy == 1.5",
     "mypy-extensions == 1.0.0",
     "pytest == 7.1.1",
     "pytest-cov == 3.0.0",

--- a/zetta_utils/geometry/bbox_strider.py
+++ b/zetta_utils/geometry/bbox_strider.py
@@ -166,7 +166,9 @@ class BBoxStrider:
             )
         )
         bbox_size_in_unit = self.bbox.end - self.bbox.start
-        step_limits_raw: Vec3D[float] = Vec3D[float](
+        # TODO: Type this variable again once typeguard bug has been fixed:
+        # https://github.com/agronholm/typeguard/issues/380
+        step_limits_raw = Vec3D[float](
             *(
                 (b - s) / st + 1
                 for b, s, st in zip(


### PR DESCRIPTION
Got rid of a type annotation due to this bug in typeguard: https://github.com/agronholm/typeguard/issues/380.

Decided to bump mypy while I was at it as well.

Fixes #457 