### PR TITLE
feat: allow supplying no op_kwargs

### DIFF
--- a/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d14ad218ffcc45d5adc3f6adbf961d8bb543fe94634c6061546f11ac846dcb7a
+size 25899

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e48a6bb76d6c51952377222234392bb14dae0c06e42160467ea8b8f5ee037504
+size 25923

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99be94782f315b632690012aa4007a7f337f5d47d44b4a5eaf237aa37992a42c
+size 26361

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:227fef254aaa80b0ca00f2cc080f8ed5045f61cfc71219313882634866d930ec
+size 25904

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7c6878da1c3a8f715af00011110aeac9903c4f417f796019e437473a75e57da
+size 26125

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_bbox/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb05692cf27006769ea29b41152cb8f688537fcff53951b16b1fd61cb9b81dc5
+size 1089

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2001-2002.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2001-2002.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb05692cf27006769ea29b41152cb8f688537fcff53951b16b1fd61cb9b81dc5
+size 1089

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2002-2003.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2002-2003.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb05692cf27006769ea29b41152cb8f688537fcff53951b16b1fd61cb9b81dc5
+size 1089

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2003-2004.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2003-2004.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb05692cf27006769ea29b41152cb8f688537fcff53951b16b1fd61cb9b81dc5
+size 1089

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2004-2005.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/128_128_40/2048-3072_2048-3072_2004-2005.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb05692cf27006769ea29b41152cb8f688537fcff53951b16b1fd61cb9b81dc5
+size 1089

--- a/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/info
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_no_op_kwargs/info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aae609c5d42d325d9034511756433dc328bae60fabc1105dacfc7deca662ee
+size 1507

--- a/tests/integration/subchunkable/test_subchunkable.py
+++ b/tests/integration/subchunkable/test_subchunkable.py
@@ -89,6 +89,8 @@ def are_dir_trees_equal(dir1, dir2):
 @pytest.mark.parametrize(
     "cue_name",
     [
+        "test_uint8_copy_bbox",
+        "test_uint8_copy_no_op_kwargs",
         "test_uint8_copy_coords",
         "test_uint8_copy_expand_bbox_resolution",
         "test_uint8_copy_expand_bbox_processing",

--- a/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
@@ -99,7 +99,7 @@ def build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg,
     fn: Callable[P, Tensor] | None = None,
     op: VolumetricOpProtocol[P, None, Any] | None = None,
     op_args: Iterable = (),
-    op_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    op_kwargs: Mapping[str, Any] | None = None,
     bbox: BBox3D | None = None,
     start_coord: Sequence[int] | None = None,
     end_coord: Sequence[int] | None = None,
@@ -218,6 +218,11 @@ def build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg,
         assert fn is not None
         op_ = VolumetricCallableOperation[P](fn)
 
+    if op_kwargs is not None:
+        op_kwargs_ = op_kwargs
+    else:
+        op_kwargs_ = {}
+
     if generate_ng_link and not print_summary:
         raise ValueError("Cannot use `generate_ng_link` when `print_summary=False`.")
 
@@ -325,7 +330,7 @@ def build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg,
         print_summary=print_summary,
         generate_ng_link=generate_ng_link,
         op_args=op_args,
-        op_kwargs=op_kwargs,
+        op_kwargs=op_kwargs_,
     )
 
 


### PR DESCRIPTION
`test_uint8_copy_bbox` was a missing integration test.