### PR TITLE
Support mapping as input for most tensor ops

### DIFF
--- a/mypy_plugin.py
+++ b/mypy_plugin.py
@@ -3,9 +3,76 @@ from __future__ import annotations
 
 from typing import Callable, Final, Optional
 
-from mypy.plugin import ClassDefContext, Plugin
+from mypy.nodes import ARG_POS
+from mypy.plugin import ClassDefContext, FunctionContext, Plugin
 from mypy.plugins.common import add_method_to_class  # add_attribute_to_class,
-from mypy.types import AnyType, Parameters, TypeOfAny
+from mypy.types import (
+    AnyType,
+    CallableType,
+    Instance,
+    Overloaded,
+    Parameters,
+    TypeOfAny,
+    TypeVarType,
+)
+
+MAZEPA_INSTALLED = False
+try:
+    from zetta_utils import mazepa  # pylint: disable
+
+    MAZEPA_INSTALLED = True
+except ImportError:
+    pass
+
+
+def supports_dict_callback(ctx):
+    original_function_type = ctx.arg_types[0][0]
+
+    if not isinstance(original_function_type, CallableType):
+        ctx.api.fail("Argument to 'supports_dict' must be callable", ctx.context)
+        return original_function_type
+
+    if not original_function_type.arg_types:
+        ctx.api.fail("Function must have at least one argument", ctx.context)
+        return original_function_type
+
+    original_arg_type = original_function_type.arg_types[0]
+
+    if isinstance(original_arg_type, AnyType):
+        ctx.api.fail("The first argument must be annotated", ctx.context)
+        return original_function_type
+
+    # if (
+    #     original_arg_type.type.fullname == "builtins.dict"
+    #     or original_arg_type.type.fullname == "typing.Mapping"
+    # ):
+    #     ctx.api.fail(
+    #         "The first argument must not be of type 'dict' or 'Mapping'", ctx.context
+    #     )
+    #     return True
+
+    original_ret_type = original_function_type.ret_type
+
+    str_type = ctx.api.named_type("builtins.str")
+    dict_type = ctx.api.named_type("builtins.dict")
+    mapping_type = ctx.api.named_type("typing.Mapping")
+
+    dict_instance = Instance(
+        dict_type.type,
+        args=[str_type, original_arg_type],
+    )
+    mapping_instance = Instance(mapping_type.type, args=[str_type, original_ret_type])
+
+    overload_2 = original_function_type.copy_modified(
+        arg_types=[mapping_instance] + original_function_type.arg_types[1:],
+        arg_kinds=[ARG_POS] + original_function_type.arg_kinds[1:],
+        arg_names=["data"] + original_function_type.arg_names[1:],
+        ret_type=dict_instance,
+    )
+
+    overloaded_type = Overloaded([original_function_type, overload_2])
+
+    return overloaded_type
 
 
 def task_maker_cls_callback(ctx):  # pragma: no cover # type: ignore
@@ -82,26 +149,23 @@ TASK_FACTORY_CLS_MAKERS: Final = {
 FLOW_TYPE_CLS_MAKERS: Final = {"zetta_utils.mazepa.flows.flow_schema_cls"}
 
 
-class MazepaPlugin(Plugin):
+class ZettaPlugin(Plugin):
     def get_class_decorator_hook_2(
         self, fullname: str
     ) -> Optional[Callable[[ClassDefContext], bool]]:  # pragma: no cover
         # if fullname in TASK_FACTORY_CLS_MAKERS:
-        if "task" in fullname:
-            return task_maker_cls_callback
-        if fullname in FLOW_TYPE_CLS_MAKERS:
-            return flow_schema_cls_callback
+        if MAZEPA_INSTALLED:
+            if "task" in fullname:
+                return task_maker_cls_callback
+            if fullname in FLOW_TYPE_CLS_MAKERS:
+                return flow_schema_cls_callback
+        return None
+
+    def get_function_hook(self, fullname: str):
+        if fullname == "zetta_utils.tensor_ops.common.supports_dict":
+            return supports_dict_callback
         return None
 
 
-class DummyPlugin(Plugin):  # pragma: no cover
-    pass
-
-
 def plugin(version):  # pragma: no cover
-    try:
-        from zetta_utils import mazepa  # pylint: disable
-    except ModuleNotFoundError:
-        return DummyPlugin
-    else:
-        return MazepaPlugin
+    return ZettaPlugin

--- a/tests/unit/tensor_ops/test_common.py
+++ b/tests/unit/tensor_ops/test_common.py
@@ -709,3 +709,17 @@ def test_crop(data, crop, expected):
 def test_crop_center(data, crop, expected):
     result = common.crop_center(data, crop)
     assert_array_equal(result, expected)
+
+
+def test_supports_dict():
+    @common.supports_dict
+    def f(x, y, z=1):
+        return x + y + z
+
+    in_np, expected_np = np.array([1]), np.array([3])
+    assert_array_equal(f(in_np, 1), expected_np)
+
+    in_dict = {"ndarray": in_np, "torch": torch.tensor(in_np)}
+    expected_dict = {"ndarray": expected_np, "torch": torch.tensor(expected_np)}
+
+    assert f(in_dict, 1) == expected_dict

--- a/tests/unit/tensor_ops/test_common.py
+++ b/tests/unit/tensor_ops/test_common.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from zetta_utils.tensor_ops import common
+from zetta_utils.tensor_typing import TensorTypeVar
 
 from ..helpers import assert_array_equal
 
@@ -475,22 +476,42 @@ def array_x1_avg_pool():
             {"scale_factor": (0.5, 0.5), "unsqueeze_input_to": 3},
             "array_x1_avg_pool",
         ],
-        ["mask_x0", "mask", {"scale_factor": 0.5, "unsqueeze_input_to": 4}, "mask_x0_max_pool"],
+        [
+            "mask_x0",
+            "mask",
+            {"scale_factor": 0.5, "unsqueeze_input_to": 4},
+            "mask_x0_max_pool",
+        ],
         [
             "mask_x0",
             "mask",
             {"scale_factor": 0.5, "mask_value_thr": 0.5, "unsqueeze_input_to": 4},
             "mask_x0_max_pool_thr05",
         ],
-        ["mask_x0", "mask", {"scale_factor": 2.0, "unsqueeze_input_to": 4}, "mask_x0_ups"],
-        ["field_x0", "field", {"scale_factor": 2.0, "unsqueeze_input_to": 4}, "field_x0_ups"],
+        [
+            "mask_x0",
+            "mask",
+            {"scale_factor": 2.0, "unsqueeze_input_to": 4},
+            "mask_x0_ups",
+        ],
+        [
+            "field_x0",
+            "field",
+            {"scale_factor": 2.0, "unsqueeze_input_to": 4},
+            "field_x0_ups",
+        ],
         [
             "field_x0",
             "field",
             {"scale_factor": [2.0, 2.0], "unsqueeze_input_to": 4},
             "field_x0_ups",
         ],
-        ["seg_x0", "segmentation", {"scale_factor": 2.0, "unsqueeze_input_to": 4}, "seg_x0_ups"],
+        [
+            "seg_x0",
+            "segmentation",
+            {"scale_factor": 2.0, "unsqueeze_input_to": 4},
+            "seg_x0_ups",
+        ],
         [
             "torch_seg_x0",
             "segmentation",
@@ -546,14 +567,24 @@ def array_6d():
         ["array_6d", "img", {"scale_factor": 0.5}, ValueError],
         ["array_1d_x0", "img", {"scale_factor": 0.357}, RuntimeError],
         ["array_1d_x0", "img", {"scale_factor": 1, "size": (1,)}, ValueError],
-        ["array_1d_x0", "img", {"size": (1, 1, 1), "unsqueeze_input_to": 3}, ValueError],
+        [
+            "array_1d_x0",
+            "img",
+            {"size": (1, 1, 1), "unsqueeze_input_to": 3},
+            ValueError,
+        ],
         [
             "array_2d_x0",
             "img",
             {"scale_factor": [1.0, 0.5, 0.5], "unsqueeze_input_to": 4},
             ValueError,
         ],
-        ["seg_uint64", "segmentation", {"scale_factor": 2.0, "unsqueeze_input_to": 4}, ValueError],
+        [
+            "seg_uint64",
+            "segmentation",
+            {"scale_factor": 2.0, "unsqueeze_input_to": 4},
+            ValueError,
+        ],
     ],
 )
 def test_interpolate_exc(data_name, mode, kwargs, request, expected_exc):
@@ -713,13 +744,13 @@ def test_crop_center(data, crop, expected):
 
 def test_supports_dict():
     @common.supports_dict
-    def f(x, y, z=1):
+    def f(x: TensorTypeVar, y, z=1):
         return x + y + z
 
     in_np, expected_np = np.array([1]), np.array([3])
     assert_array_equal(f(in_np, 1), expected_np)
 
-    in_dict = {"ndarray": in_np, "torch": torch.tensor(in_np)}
-    expected_dict = {"ndarray": expected_np, "torch": torch.tensor(expected_np)}
+    in_dict = {"ndarray": in_np, "torch": torch.Tensor(in_np)}
+    expected_dict = {"ndarray": expected_np, "torch": torch.Tensor(expected_np)}
 
     assert f(in_dict, 1) == expected_dict

--- a/zetta_utils/tensor_ops/common.py
+++ b/zetta_utils/tensor_ops/common.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 from typing import (
     Callable,
-    Hashable,
     Literal,
     Mapping,
     Optional,
@@ -21,13 +20,11 @@ from zetta_utils import builder, tensor_ops
 from zetta_utils.tensor_typing import Tensor, TensorTypeVar
 
 P = ParamSpec("P")
-T = TypeVar("T", bound=Union[Tensor, Mapping[Hashable, Tensor]])
+T = TypeVar("T")
 
 
-def supports_dict(
-    func: Callable[Concatenate[TensorTypeVar, P], TensorTypeVar]
-) -> Callable[Concatenate[T, P], T]:
-    def wrapper(data: T, *args: P.args, **kwargs: P.kwargs) -> T:
+def supports_dict(func: Callable[Concatenate[T, P], T]):
+    def wrapper(data, *args: P.args, **kwargs: P.kwargs):
         if isinstance(data, Mapping):
             return {k: func(v, *args, **kwargs) for k, v in data.items()}
         else:
@@ -113,7 +110,8 @@ def unsqueeze(
 @typechecked
 @supports_dict
 def squeeze(
-    data: TensorTypeVar, dim: Optional[Union[SupportsIndex, Sequence[SupportsIndex]]] = None
+    data: TensorTypeVar,
+    dim: Optional[Union[SupportsIndex, Sequence[SupportsIndex]]] = None,
 ) -> TensorTypeVar:
     """
     Returns a tensor with all the dimensions of input of size 1 removed.

--- a/zetta_utils/tensor_ops/convert.py
+++ b/zetta_utils/tensor_ops/convert.py
@@ -7,6 +7,7 @@ import torch
 from typeguard import typechecked
 
 from zetta_utils import builder, tensor_ops
+from zetta_utils.tensor_ops.common import supports_dict
 from zetta_utils.tensor_typing import Tensor, TensorTypeVar
 
 
@@ -73,6 +74,7 @@ def astype(data: Tensor, reference: TensorTypeVar) -> TensorTypeVar:
 
 @builder.register("to_float32")
 @typechecked
+@supports_dict
 def to_float32(data: TensorTypeVar) -> TensorTypeVar:
     """Convert the given tensor to fp32.
 
@@ -90,6 +92,7 @@ def to_float32(data: TensorTypeVar) -> TensorTypeVar:
 
 @builder.register("to_uint8")
 @typechecked
+@supports_dict
 def to_uint8(data: TensorTypeVar) -> TensorTypeVar:
     """Convert the given tensor to uint8.
 

--- a/zetta_utils/tensor_ops/mask.py
+++ b/zetta_utils/tensor_ops/mask.py
@@ -12,6 +12,7 @@ from typeguard import typechecked
 from typing_extensions import ParamSpec
 
 from zetta_utils import builder
+from zetta_utils.tensor_ops.common import supports_dict
 from zetta_utils.tensor_typing import Tensor, TensorTypeVar
 
 from . import convert
@@ -51,6 +52,7 @@ def skip_on_empty_data(fn: OpT) -> OpT:
 
 
 @builder.register("filter_cc")  # type: ignore # TODO: pyright
+@supports_dict
 @skip_on_empty_data
 @typechecked
 def filter_cc(
@@ -114,6 +116,7 @@ def _normalize_kernel(
 
 
 @builder.register("kornia_opening")  # type: ignore
+@supports_dict
 @skip_on_empty_data
 @typechecked
 def kornia_opening(
@@ -156,6 +159,7 @@ def kornia_opening(
 
 
 @builder.register("kornia_closing")  # type: ignore
+@supports_dict
 @skip_on_empty_data
 @typechecked
 def kornia_closing(
@@ -198,6 +202,7 @@ def kornia_closing(
 
 
 @builder.register("kornia_erosion")  # type: ignore
+@supports_dict
 @skip_on_empty_data
 @typechecked
 def kornia_erosion(
@@ -240,6 +245,7 @@ def kornia_erosion(
 
 
 @builder.register("kornia_dilation")  # type: ignore
+@supports_dict
 @skip_on_empty_data
 @typechecked
 def kornia_dilation(


### PR DESCRIPTION
Should resolve #447.

Only needed it for `rearrange` and `crop` to work with my input/output layer set, though.