### PR TITLE
fix(ZettaDefaultTrainer): restore wandb project/run naming

### DIFF
--- a/zetta_utils/training/lightning/trainers/default.py
+++ b/zetta_utils/training/lightning/trainers/default.py
@@ -69,7 +69,12 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
         if not os.environ.get("WANDB_MODE", None) == "offline":  # pragma: no cover
             api_key = os.environ.get("WANDB_API_KEY", None)
             wandb.login(key=api_key)
-            wandb.init(group=f"{experiment_name}.{experiment_version}")
+            wandb.init(
+                project=experiment_name,
+                group=f"{experiment_name}.{experiment_version}",
+                name=experiment_version,
+                id=experiment_version,
+            )
 
         if wandb.run is not None:
             this_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
The change in https://github.com/ZettaAI/zetta_utils/commit/9ea669ae5e9af364819975d81f4574d6c47f0c0d#diff-d7d24b371be4f087d00da084cea4983bbfe8e1d72f12ea6e737c6233d8cae702R103 overrides or unsets the `project` and `name` of the run, causing wandb to assign random names instead.

This PR should fix it, but I am not sure if that affects your DDP work, @akhileshh?