### PR TITLE
Initial implementation of info_add_scales

### DIFF
--- a/tests/unit/layer/volumetric/precomputed/test_precomputed.py
+++ b/tests/unit/layer/volumetric/precomputed/test_precomputed.py
@@ -23,6 +23,8 @@ LAYER_X6_PATH = "file://" + os.path.join(INFOS_DIR, "scratch", "layer_x6")
 LAYER_X7_PATH = "file://" + os.path.join(INFOS_DIR, "scratch", "layer_x7")
 NONEXISTENT_LAYER_PATH = "file://" + os.path.join(INFOS_DIR, "scratch", "nonexistent_layer")
 
+EXAMPLE_INFO = '{"data_type": "uint8", "num_channels": 1, "scales": [{"chunk_sizes": [[1024, 1024, 1]], "encoding": "raw", "key": "4_4_40", "resolution": [4, 4, 40], "size": [16384, 16384, 16384], "voxel_offset": [0, 0, 0]}, {"chunk_sizes": [[2048, 2048, 1]], "encoding": "raw", "key": "8_8_40", "resolution": [8, 8, 40], "size": [8192, 8192, 8192], "voxel_offset": [0, 0, 0]}], "type": "raw"}'
+
 _write_info_notmock = precomputed._write_info
 
 
@@ -102,3 +104,225 @@ def test_ts_set_voxel_set_voxel_offset_chunk_and_data(clear_caches, mocker):
             assert scale["voxel_offset"] == [1, 2, 3]
             assert scale["chunk_sizes"][0] == [3, 2, 1]
             assert scale["size"] == [10, 20, 30]
+
+
+def make_tmp_layer(tmpdir, info_text=None):
+    if info_text is None:
+        info_text = EXAMPLE_INFO
+    tmpdir_info = tmpdir.join("info")
+    tmpdir_info.write(info_text)
+    return str(tmpdir)
+
+
+@pytest.mark.parametrize(
+    "in_scales, expects",
+    [
+        # test shorthand
+        [[[16, 16, 40]], ["16_16_40"]],
+        # test multiples
+        [[[16, 16, 40], [32, 32, 40]], ["16_16_40", "32_32_40"]],
+        # test minimum spec of just `resolution`
+        [[{"resolution": [16, 16, 40]}], ["16_16_40"]],
+        # test mixed
+        [[{"resolution": [16, 16, 40]}, [32, 32, 40]], ["16_16_40", "32_32_40"]],
+    ],
+)
+def test_add_scale(clear_caches, tmpdir, in_scales, expects):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=in_scales,
+    )
+    info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+    scales = get_info(tmp_layer)["scales"]
+    for expect in expects:
+        assert expect in [e["key"] for e in scales]
+
+
+@pytest.mark.parametrize(
+    "mode, expects",
+    [
+        ["merge", ["4_4_40", "8_8_40", "16_16_40"]],
+        ["replace", ["16_16_40"]],
+    ],
+)
+def test_add_scale_modes(clear_caches, tmpdir, mode, expects):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[[16, 16, 40]],
+        add_scales_mode=mode,
+    )
+    info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+    scales = get_info(tmp_layer)["scales"]
+    for expect in expects:
+        assert expect in [e["key"] for e in scales]
+
+
+def test_add_scale_modes_error(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    with pytest.raises(RuntimeError):
+        info_spec = PrecomputedInfoSpec(
+            reference_path=tmp_layer,
+            add_scales=[[16, 16, 40]],
+            add_scales_mode="append",
+        )
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+
+
+def test_add_scale_full_entry(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[
+            {
+                "key": "asdf8",
+                "resolution": [8, 8, 40],
+                "chunk_sizes": [[32, 32, 1]],
+                "encoding": "raw",
+                "size": [1000, 1000, 1000],
+                "voxel_offset": [1, 2, 3],
+            },
+            {
+                "resolution": [33, 33, 40],
+                "chunk_sizes": [[7, 8, 9]],
+                "encoding": "raw",
+                "size": [1000, 1000, 1000],
+                "voxel_offset": [4, 5, 6],
+            },
+        ],
+    )
+    info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+    scales = get_info(tmp_layer)["scales"]
+    assert "asdf8" in [e["key"] for e in scales]
+    assert "33_33_40" in [e["key"] for e in scales]
+    for scale in scales:
+        if scale["key"] == "asdf8":
+            assert scale["voxel_offset"] == [1, 2, 3]
+        if scale["key"] == "33_33_40":
+            assert scale["chunk_sizes"] == [[7, 8, 9]]
+
+
+def test_add_scale_with_ref(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales_ref="8_8_40",
+        add_scales=[[16, 16, 40]],
+    )
+    info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+    scales = get_info(tmp_layer)["scales"]
+    assert "16_16_40" in [e["key"] for e in scales]
+
+
+def test_add_scale_error_non_multiple(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[[6, 6, 82]],
+    )
+    with pytest.raises(RuntimeError):
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+
+
+def test_add_scale_error_no_ref_scales(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    info = '{"data_type": "uint8", "num_channels": 1, "type": "raw"}'
+    tmp_layer = make_tmp_layer(tmpdir, info_text=info)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[[16, 16, 40]],
+    )
+    with pytest.raises(RuntimeError):
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+
+
+def test_add_scale_with_overrides_okay(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[[16, 16, 40]],
+        field_overrides={"type": "uint8"},
+    )
+    info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+
+
+def test_add_scale_with_overrides_error(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[[16, 16, 40]],
+        field_overrides={
+            "scales": [
+                {
+                    "chunk_sizes": [[1024, 1024, 1]],
+                    "encoding": "raw",
+                    "key": "4_4_40",
+                    "resolution": [4, 4, 40],
+                    "size": [16384, 16384, 16384],
+                    "voxel_offset": [0, 0, 0],
+                }
+            ]
+        },
+    )
+    with pytest.raises(RuntimeError):
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+
+
+def test_add_scale_with_custom_ref(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales_ref={
+            "key": "3_3_41",
+            "resolution": [3, 3, 41],
+            "chunk_sizes": [[512, 512, 1]],
+            "encoding": "raw",
+            "size": [1000, 1000, 1000],
+            "voxel_offset": [2, 4, 6],
+        },
+        add_scales=[[6, 6, 82]],
+    )
+    info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+    scales = get_info(tmp_layer)["scales"]
+    assert "6_6_82" in [e["key"] for e in scales]
+
+
+def test_add_scale_error_offset_scaling(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales_ref={
+            "key": "3_3_41",
+            "resolution": [3, 3, 41],
+            "chunk_sizes": [[512, 512, 1]],
+            "encoding": "raw",
+            "size": [1000, 1000, 1000],
+            "voxel_offset": [1, 4, 6],
+        },
+        add_scales=[[6, 6, 82]],
+    )
+    with pytest.raises(RuntimeError):
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")
+
+
+def test_add_scale_with_non_existing_ref(clear_caches, tmpdir):
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales_ref="32_32_40",
+        add_scales=[[16, 16, 40]],
+    )
+    with pytest.raises(RuntimeError):
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")

--- a/tests/unit/layer/volumetric/precomputed/test_precomputed.py
+++ b/tests/unit/layer/volumetric/precomputed/test_precomputed.py
@@ -180,14 +180,7 @@ def test_add_scale_full_entry(clear_caches, tmpdir):
         reference_path=tmp_layer,
         add_scales=[
             {
-                "key": "asdf8",
-                "resolution": [8, 8, 40],
-                "chunk_sizes": [[32, 32, 1]],
-                "encoding": "raw",
-                "size": [1000, 1000, 1000],
-                "voxel_offset": [1, 2, 3],
-            },
-            {
+                "key": "33_33_40",
                 "resolution": [33, 33, 40],
                 "chunk_sizes": [[7, 8, 9]],
                 "encoding": "raw",
@@ -198,13 +191,31 @@ def test_add_scale_full_entry(clear_caches, tmpdir):
     )
     info_spec.update_info(tmp_layer, on_info_exists="overwrite")
     scales = get_info(tmp_layer)["scales"]
-    assert "asdf8" in [e["key"] for e in scales]
     assert "33_33_40" in [e["key"] for e in scales]
     for scale in scales:
-        if scale["key"] == "asdf8":
-            assert scale["voxel_offset"] == [1, 2, 3]
         if scale["key"] == "33_33_40":
             assert scale["chunk_sizes"] == [[7, 8, 9]]
+
+
+def test_add_scale_unsupported_keys(clear_caches, tmpdir):
+    """Throw error if key does not match resolution"""
+    precomputed._write_info = _write_info_notmock
+    tmp_layer = make_tmp_layer(tmpdir)
+    info_spec = PrecomputedInfoSpec(
+        reference_path=tmp_layer,
+        add_scales=[
+            {
+                "key": "40_33_33",
+                "resolution": [33, 33, 40],
+                "chunk_sizes": [[7, 8, 9]],
+                "encoding": "raw",
+                "size": [1000, 1000, 1000],
+                "voxel_offset": [4, 5, 6],
+            },
+        ],
+    )
+    with pytest.raises(RuntimeError):
+        info_spec.update_info(tmp_layer, on_info_exists="overwrite")
 
 
 def test_add_scale_with_ref(clear_caches, tmpdir):

--- a/zetta_utils/layer/volumetric/cloudvol/build.py
+++ b/zetta_utils/layer/volumetric/cloudvol/build.py
@@ -34,6 +34,9 @@ def build_cv_layer(  # pylint: disable=too-many-locals
     info_dataset_size_map: dict[str, Sequence[int]] | None = None,
     info_voxel_offset: Sequence[int] | None = None,
     info_voxel_offset_map: dict[str, Sequence[int]] | None = None,
+    info_add_scales: Sequence[Sequence[int] | dict[str, Any]] | None = None,
+    info_add_scales_ref: str | dict[str, Any] | None = None,
+    info_add_scales_mode: str = "merge",
     on_info_exists: InfoExistsModes = "expect_same",
     allow_slice_rounding: bool = False,
     index_procs: Iterable[IndexProcessor[VolumetricIndex]] = (),
@@ -71,6 +74,16 @@ def build_cv_layer(  # pylint: disable=too-many-locals
     :param info_dataset_size_map: Precomputed dataset size for each resolution.
     :param info_voxel_offset: Precomputed voxel offset for all scales.
     :param info_voxel_offset_map: Precomputed voxel offset for each resolution.
+    :param info_add_scales: List of scales to be added based on ``info_add_scales_ref``
+        Each entry can be either a resolution (e.g., [4, 4, 40]) or a partially filled
+        Precomputed scale. By default, ``size`` and ``voxel_offset`` will be scaled
+        accordingly to the reference scale, while keeping ``chunk_sizes`` the same.
+        Note that using ``info_[chunk,dataset,voxel]_size[_map]`` will override
+        these values.
+    :param info_add_scales_ref: Reference scale to be used.
+    :param info_add_scales_mode: Either "merge" or "replace". "merge" will
+        merge added scales to existing scales if ``info_reference_path`` is
+        used, while "replace" will not keep them.
     :param on_info_exists: Behavior mode for when both new info specs aregiven
         and layer info already exists.
     :param allow_slice_rounding: Whether layer allows IO operations where the specified index
@@ -100,6 +113,9 @@ def build_cv_layer(  # pylint: disable=too-many-locals
             dataset_size_map=info_dataset_size_map,
             default_voxel_offset=info_voxel_offset,
             voxel_offset_map=info_voxel_offset_map,
+            add_scales=info_add_scales,
+            add_scales_ref=info_add_scales_ref,
+            add_scales_mode=info_add_scales_mode,
         ),
     )
 

--- a/zetta_utils/layer/volumetric/cloudvol/build.py
+++ b/zetta_utils/layer/volumetric/cloudvol/build.py
@@ -78,8 +78,8 @@ def build_cv_layer(  # pylint: disable=too-many-locals
         Each entry can be either a resolution (e.g., [4, 4, 40]) or a partially filled
         Precomputed scale. By default, ``size`` and ``voxel_offset`` will be scaled
         accordingly to the reference scale, while keeping ``chunk_sizes`` the same.
-        Note that using ``info_[chunk,dataset,voxel]_size[_map]`` will override
-        these values.
+        Note that using ``info_[chunk_size,dataset_size,voxel_offset][_map]`` will
+        override these values.
     :param info_add_scales_ref: Reference scale to be used.
     :param info_add_scales_mode: Either "merge" or "replace". "merge" will
         merge added scales to existing scales if ``info_reference_path`` is

--- a/zetta_utils/layer/volumetric/cloudvol/build.py
+++ b/zetta_utils/layer/volumetric/cloudvol/build.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 from __future__ import annotations
 
-from typing import Any, Iterable, Sequence, Union
+from typing import Any, Iterable, Literal, Sequence, Union
 
 import torch
 
@@ -36,7 +36,7 @@ def build_cv_layer(  # pylint: disable=too-many-locals
     info_voxel_offset_map: dict[str, Sequence[int]] | None = None,
     info_add_scales: Sequence[Sequence[int] | dict[str, Any]] | None = None,
     info_add_scales_ref: str | dict[str, Any] | None = None,
-    info_add_scales_mode: str = "merge",
+    info_add_scales_mode: Literal["merge", "replace"] = "merge",
     on_info_exists: InfoExistsModes = "expect_same",
     allow_slice_rounding: bool = False,
     index_procs: Iterable[IndexProcessor[VolumetricIndex]] = (),
@@ -79,7 +79,8 @@ def build_cv_layer(  # pylint: disable=too-many-locals
         Precomputed scale. By default, ``size`` and ``voxel_offset`` will be scaled
         accordingly to the reference scale, while keeping ``chunk_sizes`` the same.
         Note that using ``info_[chunk_size,dataset_size,voxel_offset][_map]`` will
-        override these values.
+        override these values. Using this will also sort the added and existing scales
+        by their resolutions.
     :param info_add_scales_ref: Reference scale to be used. If `None`, use
         the highest available resolution scale.
     :param info_add_scales_mode: Either "merge" or "replace". "merge" will

--- a/zetta_utils/layer/volumetric/cloudvol/build.py
+++ b/zetta_utils/layer/volumetric/cloudvol/build.py
@@ -80,7 +80,8 @@ def build_cv_layer(  # pylint: disable=too-many-locals
         accordingly to the reference scale, while keeping ``chunk_sizes`` the same.
         Note that using ``info_[chunk_size,dataset_size,voxel_offset][_map]`` will
         override these values.
-    :param info_add_scales_ref: Reference scale to be used.
+    :param info_add_scales_ref: Reference scale to be used. If `None`, use
+        the highest available resolution scale.
     :param info_add_scales_mode: Either "merge" or "replace". "merge" will
         merge added scales to existing scales if ``info_reference_path`` is
         used, while "replace" will not keep them.


### PR DESCRIPTION
For issue https://github.com/ZettaAI/zetta_utils/issues/500.

Update 10/6/23: `add_scales_ref = None` (default) will use the highest resolution scale as reference.

Annotated example of current implementation:
```
{
    "@type": "build_cv_layer"
    path: #DST_PATH
    ref_info: ...

    // add_scales_ref can either be a dictionary
    add_scales_ref: {
        "key": "4_4_40",
        "resolution": [4, 4, 40],
        "chunk_sizes": [[512, 512, 1]],
        "encoding": "raw",
        "size": [1000, 1000, 1000],
        "voxel_offset": [0, 0, 0]
    }
    // Or an existing key from `ref_info` from which the dict will be copied from.
    // Throws an error if `ref_info` if key is not found
    add_scales_ref: [4, 4, 40]
    // Or `None` to use the highest resolution scale
    add_scales_ref: null

    // Example adding 3 scales.
    add_scales: [
        {
            // Example of a fully speced entry
            "key": "asdf8", // can be anything
            "resolution": [8, 8, 40],
            "chunk_sizes": [[32, 32, 1]],
            "encoding": "raw",
            "size": [1000, 1000, 1000],
            "voxel_offset": [1, 2, 3]
        },

        {   
            // Example of a partial entry - missing parameters will be filled in by scaling values from `add_scales_ref`
            // `resolution` is the only required parameter. `key` will be `resolution` underscore-separated if not given.
            // The following required properties will be computed if not specified: chunk_sizes, encoding, size, & voxel_offset
            // Error cases:
            // 1. `add_scales_ref` doesn't have values for required properties
            // 2. Values are not integers after scaling.
            // To resolve, just provide the mismatched properties here.
            "resolution": [16, 16, 40],
        },  

        [32, 32, 40],  // shorthand, equivalent to `{"resolution": [8, 8, 40]}`
    ]

    // two modes: "merge" (default) and "replace"
    info_add_scales_mode: "merge"       // "merge" will merge added scales to existing scales from `ref_info` (if provided)
    info_add_scales_mode: "replace"     // "replace" will not keep existing scales

    info_chunk_size: [1024, 1024, 1]  // using ``info_[chunk_size,dataset_size,voxel_offset][_map]`` will override the computed values
}
```