### PR TITLE
feat: preserve tuples in JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ max-line-length = 99
 max-locals = 25
 
 [tool.pylint.basic]
-good-names = '''sm,lr,ts,df,e,i,j,k,id,logger,n,on,tz,x,y,z,r,ex,ey,cv,s,f,v,a,b,mu,fn,op,q,cf,tb'''
+good-names = '''sm,lr,ts,df,e,i,j,k,id,logger,n,on,tz,x,y,z,r,ex,ey,cv,s,f,v,a,b,mu,fn,fp,op,q,cf,tb'''
 additional-builtins = '''reveal_type'''
 [tool.pylint.message_control]
 disable = '''duplicate-code,C0330,cyclic-import,too-many-arguments,missing-docstring,too-few-public-methods,logging-fstring-interpolation,logging-not-lazy,not-callable,no-member,unsubscriptable-object,pointless-string-statement,wrong-import-order,not-an-iterable,no-else-return,unsupported-membership-test,abstract-class-instantiated,unpacking-non-sequence'''

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,10 +1,9 @@
 # pylint: disable=unused-argument,redefined-outer-name
-import json
-
 import pytest
 from click.testing import CliRunner
 
 from zetta_utils import builder, cli
+from zetta_utils.parsing import json
 
 
 @pytest.fixture

--- a/tests/unit/parsing/test_json.py
+++ b/tests/unit/parsing/test_json.py
@@ -1,0 +1,36 @@
+from io import StringIO
+
+from zetta_utils.parsing import json
+
+
+def test_str_roundtrip():
+    assert json.loads(json.dumps({"1": "2"})) == {"1": "2"}
+
+
+def test_str_tuple_roundtrip():
+    assert json.loads(json.dumps((1, "2"))) == (1, "2")
+
+
+def test_str_nested_tuple_roundtrip():
+    assert json.loads(json.dumps((1, "2", (3, "4")))) == (1, "2", (3, "4"))
+
+
+def test_fp_roundtrip():
+    fp = StringIO()
+    json.dump({"1": "2"}, fp)
+    fp.seek(0)
+    assert json.load(fp) == {"1": "2"}
+
+
+def test_fp_tuple_roundtrip():
+    fp = StringIO()
+    json.dump((1, "2"), fp)
+    fp.seek(0)
+    assert json.load(fp) == (1, "2")
+
+
+def test_fp_nested_tuple_roundtrip():
+    fp = StringIO()
+    json.dump((1, "2", (3, "4")), fp)
+    fp.seek(0)
+    assert json.load(fp) == (1, "2", (3, "4"))

--- a/zetta_utils/builder/build.py
+++ b/zetta_utils/builder/build.py
@@ -1,7 +1,6 @@
 """Bulding objects from nested specs."""
 from __future__ import annotations
 
-import json
 from typing import Any, Callable, Final, Optional
 
 import attrs
@@ -9,6 +8,7 @@ from typeguard import typechecked
 
 from zetta_utils import parsing
 from zetta_utils.common import ctx_managers
+from zetta_utils.parsing import json
 
 from . import constants
 from .registry import get_matching_entry
@@ -183,7 +183,6 @@ class BuilderPartial:
 
     def _get_built_spec_kwargs(self, version: str) -> dict[str, Any]:
         if self._built_spec_kwargs is None:
-
             self._built_spec_kwargs = {
                 k: _traverse_spec(
                     v,

--- a/zetta_utils/cli/main.py
+++ b/zetta_utils/cli/main.py
@@ -1,4 +1,3 @@
-import json
 import os
 import pprint
 from typing import Optional
@@ -7,6 +6,7 @@ import click
 
 import zetta_utils
 from zetta_utils import log
+from zetta_utils.parsing import json
 
 logger = log.get_logger("zetta_utils")
 

--- a/zetta_utils/cloud_management/execution_tracker.py
+++ b/zetta_utils/cloud_management/execution_tracker.py
@@ -1,4 +1,3 @@
-import json
 import os
 import time
 from contextlib import contextmanager
@@ -14,6 +13,7 @@ from zetta_utils.common import RepeatTimer
 from zetta_utils.layer.db_layer import DBRowDataT, build_db_layer
 from zetta_utils.layer.db_layer.datastore import DatastoreBackend
 from zetta_utils.log import get_logger
+from zetta_utils.parsing import json
 
 from .resource_allocation.k8s import ClusterInfo
 

--- a/zetta_utils/parsing/__init__.py
+++ b/zetta_utils/parsing/__init__.py
@@ -1,2 +1,3 @@
 from . import cue
 from . import ngl_state
+from . import json

--- a/zetta_utils/parsing/cue.py
+++ b/zetta_utils/parsing/cue.py
@@ -1,5 +1,4 @@
 """cuelang parsing."""
-import json
 import os
 import pathlib
 import subprocess
@@ -8,6 +7,7 @@ import tempfile
 import fsspec
 
 from zetta_utils import log
+from zetta_utils.parsing import json
 
 logger = log.get_logger("zetta_utils")
 

--- a/zetta_utils/parsing/json.py
+++ b/zetta_utils/parsing/json.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from _typeshed import SupportsRead, SupportsWrite  # pragma: no cover
+
+
+def _mark_python_types(obj: Any) -> Any:
+    if isinstance(obj, tuple):
+        return {"__tuple__": [_mark_python_types(e) for e in obj]}
+    if isinstance(obj, list):
+        return [_mark_python_types(e) for e in obj]
+    if isinstance(obj, dict):
+        return {key: _mark_python_types(value) for key, value in obj.items()}
+    else:
+        return obj
+
+
+class ZettaSpecJSONEncoder(json.JSONEncoder):
+    def encode(self, o: Any) -> str:
+        return super().encode(_mark_python_types(o))
+
+    def iterencode(self, o: Any, _one_shot: bool = False) -> Iterator[str]:
+        return super().iterencode(_mark_python_types(o), _one_shot=_one_shot)
+
+
+def tuple_hook(obj):
+    if "__tuple__" in obj:
+        return tuple(obj["__tuple__"])
+    else:
+        return obj
+
+
+def dumps(obj, **kwargs) -> str:
+    return json.dumps(obj, cls=ZettaSpecJSONEncoder, **kwargs)
+
+
+def dump(obj: Any, fp: SupportsWrite[str], **kwargs) -> None:
+    json.dump(obj, fp, cls=ZettaSpecJSONEncoder, **kwargs)
+
+
+def loads(s: str | bytes | bytearray, **kwargs) -> Any:
+    return json.loads(s, object_hook=tuple_hook, **kwargs)
+
+
+def load(fp: SupportsRead[str | bytes], **kwargs) -> Any:
+    return json.load(fp, object_hook=tuple_hook, **kwargs)

--- a/zetta_utils/training/lightning/train.py
+++ b/zetta_utils/training/lightning/train.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 from contextlib import ExitStack
 from typing import Any, Dict, Final, List, Optional
@@ -16,6 +15,7 @@ from kubernetes import client as k8s_client  # type: ignore
 from zetta_utils import builder, load_all_modules, log, mazepa, parsing
 from zetta_utils.builder.build import BuilderPartial
 from zetta_utils.cloud_management import execution_tracker, resource_allocation
+from zetta_utils.parsing import json
 
 logger = log.get_logger("zetta_utils")
 

--- a/zetta_utils/training/lightning/trainers/default.py
+++ b/zetta_utils/training/lightning/trainers/default.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import importlib.metadata
-import json
 import os
 from typing import Any, Dict, List, Optional
 
@@ -15,6 +14,7 @@ from pytorch_lightning.loggers import WandbLogger
 from pytorch_lightning.strategies import ddp
 
 from zetta_utils import builder, log
+from zetta_utils.parsing import json
 
 logger = log.get_logger("zetta_utils")
 ONNX_OPSET_VERSION = 17
@@ -126,7 +126,6 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
     def save_checkpoint(
         self, filepath, weights_only: bool = False, storage_options: Optional[Any] = None
     ):  # pylint: disable=too-many-locals
-
         if filepath.startswith("./"):
             filepath = f"{self.default_root_dir}/{filepath[2:]}"
         super().save_checkpoint(filepath, weights_only, storage_options)


### PR DESCRIPTION
With this PR, tuples will be JSON encoded as list with a `__tuple__` marker as first element. The tuple preservation is required for libraries that differentiate between Python tuples and lists, i.e. `imgaug` treats tuples as value ranges to pick from, but JSON silently converts them to lists (discrete values)

Slows down JSON encoding/decoding a bit, but I don't think we use JSON for high-performance operations, anyway.