### PR TITLE
feat(k8s): allow distinct resource limits/requests

### DIFF
--- a/zetta_utils/cloud_management/resource_allocation/k8s/cronjob.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/cronjob.py
@@ -25,10 +25,11 @@ def _get_cronjob(
     command: List[str],
     command_args: List[str],
     envs: List[k8s_client.V1EnvVar],
-    resources: Dict[str, int | float | str],
+    resource_limits: Dict[str, int | float | str],
     spec_config: CronJobSpecConfig,
     labels: Optional[Dict[str, str]] = None,
     tolerations: Optional[k8s_client.V1Toleration] = None,
+    resource_requests: Optional[Dict[str, int | float | str]] = None,
 ) -> k8s_client.V1CronJob:
     tolerations = tolerations or []
     pod_spec = get_pod_spec(
@@ -37,9 +38,10 @@ def _get_cronjob(
         command=command,
         command_args=command_args,
         envs=envs,
-        resources=resources,
+        resources=resource_limits,
         restart_policy="OnFailure",
         tolerations=tolerations,
+        resource_requests=resource_requests,
     )
 
     job_template = get_job_template(
@@ -88,6 +90,7 @@ def configure_cronjob(
     spec_config: CronJobSpecConfig = CronJobSpecConfig(),
     labels: Optional[Dict[str, str]] = None,
     patch: Optional[bool] = False,
+    resource_requests: Optional[Dict[str, int | float | str]] = None,
 ):
     """
     Create a cronjob or patch/update an existing one.
@@ -113,9 +116,10 @@ def configure_cronjob(
         command=command,
         command_args=command_args,
         envs=envs,
-        resources=resources,
+        resource_limits=resources,
         spec_config=spec_config,
         labels=labels,
+        resource_requests=resource_requests,
     )
     if patch:
         batch_v1_api.patch_namespaced_cron_job(name=name, namespace=namespace, body=cronjob)

--- a/zetta_utils/cloud_management/resource_allocation/k8s/deployment.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/deployment.py
@@ -32,6 +32,7 @@ def get_deployment_spec(
     env_secret_mapping: Dict[str, str],
     volumes: Optional[List[k8s_client.V1Volume]] = None,
     volume_mounts: Optional[List[k8s_client.V1VolumeMount]] = None,
+    resource_requests: Optional[Dict[str, int | float | str]] = None,
 ) -> k8s_client.V1Deployment:
     schedule_toleration = k8s_client.V1Toleration(
         key="worker-pool", operator="Equal", value="true", effect="NoSchedule"
@@ -47,6 +48,7 @@ def get_deployment_spec(
         tolerations=[schedule_toleration],
         volumes=volumes,
         volume_mounts=volume_mounts,
+        resource_requests=resource_requests,
     )
 
     pod_template = k8s_client.V1PodTemplateSpec(
@@ -84,6 +86,7 @@ def get_mazepa_worker_deployment(  # pylint: disable=too-many-locals
     resources: Dict[str, int | float | str],
     env_secret_mapping: Dict[str, str],
     labels: Optional[Dict[str, str]] = None,
+    resource_requests: Optional[Dict[str, int | float | str]] = None,
 ):
     if labels is None:
         labels_final = {"execution_id": execution_id}
@@ -115,6 +118,7 @@ def get_mazepa_worker_deployment(  # pylint: disable=too-many-locals
         env_secret_mapping=env_secret_mapping,
         volumes=volumes,
         volume_mounts=volume_mounts,
+        resource_requests=resource_requests,
     )
 
 

--- a/zetta_utils/cloud_management/resource_allocation/k8s/pod.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/pod.py
@@ -32,6 +32,7 @@ def get_pod_spec(
     tolerations: Optional[List[k8s_client.V1Toleration]] = None,
     volumes: Optional[List[k8s_client.V1Volume]] = None,
     volume_mounts: Optional[List[k8s_client.V1VolumeMount]] = None,
+    resource_requests: Optional[Dict[str, int | float | str]] = None,
 ) -> k8s_client.V1PodSpec:
 
     envs = envs or []
@@ -49,8 +50,8 @@ def get_pod_spec(
         image_pull_policy=image_pull_policy,
         ports=ports,
         resources=k8s_client.V1ResourceRequirements(
-            requests=resources,
             limits=resources,
+            requests=resource_requests or resources,
         ),
         termination_message_path="/dev/termination-log",
         termination_message_policy="File",

--- a/zetta_utils/mazepa_addons/configurations/execute_on_gcp_with_sqs.py
+++ b/zetta_utils/mazepa_addons/configurations/execute_on_gcp_with_sqs.py
@@ -56,6 +56,7 @@ def get_gcp_with_sqs_config(
     worker_resources: Dict[str, int | float | str],
     worker_labels: Optional[Dict[str, str]],
     ctx_managers: list[AbstractContextManager],
+    worker_resource_requests: Optional[Dict[str, int | float | str]] = None,
 ) -> tuple[PushMessageQueue[Task], PullMessageQueue[OutcomeReport], list[AbstractContextManager]]:
     work_queue_name = f"zzz-{execution_id}-work"
     outcome_queue_name = f"zzz-{execution_id}-outcome"
@@ -92,6 +93,7 @@ def get_gcp_with_sqs_config(
         resources=worker_resources,
         env_secret_mapping=env_secret_mapping,
         labels=worker_labels,
+        resource_requests=worker_resource_requests,
     )
 
     ctx_managers.append(
@@ -124,6 +126,7 @@ def execute_on_gcp_with_sqs(  # pylint: disable=too-many-locals
     checkpoint: Optional[str] = None,
     checkpoint_interval_sec: float = 300.0,
     raise_on_failed_checkpoint: bool = True,
+    worker_resource_requests: Optional[Dict[str, int | float | str]] = None,
 ):
     _ensure_required_env_vars()
     execution_id = mazepa.id_generation.get_unique_id(
@@ -166,6 +169,7 @@ def execute_on_gcp_with_sqs(  # pylint: disable=too-many-locals
             worker_replicas=worker_replicas,
             worker_resources=worker_resources if worker_resources else {},
             ctx_managers=ctx_managers,
+            worker_resource_requests=worker_resource_requests,
         )
 
     with ExitStack() as stack:

--- a/zetta_utils/training/lightning/train.py
+++ b/zetta_utils/training/lightning/train.py
@@ -161,13 +161,14 @@ def _create_ddp_master_job(
     *,
     cluster_info: resource_allocation.k8s.ClusterInfo,
     image: str,
-    resources: dict,
+    resource_limits: dict[str, int | float | str],
     train_spec: dict,
     num_nodes: int,
     retry_count: int,
     env_vars: Optional[Dict[str, str]] = None,
     follow_logs: Optional[bool] = False,
     host_network: Optional[bool] = False,
+    resource_requests: Optional[dict[str, int | float | str]] = None,
 ):  # pylint: disable=too-many-locals
     zetta_cmd = "zetta run specs/train.cue"
     env_vars = env_vars or {}
@@ -216,7 +217,7 @@ def _create_ddp_master_job(
         env_secret_mapping=env_secret_mapping,
         hostname="master",
         host_network=host_network,
-        resources=resources,
+        resources=resource_limits,
         restart_policy="Never",
         # with multinode ddp we need a node on standard pool for an IP
         # that remains the same for the duration of training
@@ -225,6 +226,7 @@ def _create_ddp_master_job(
         tolerations=_get_tolerations(role="master" if num_nodes > 1 else "worker"),
         volumes=volumes,
         volume_mounts=mounts,
+        resource_requests=resource_requests,
     )
 
     train_job_failure_policy = k8s_client.V1PodFailurePolicy(
@@ -271,10 +273,11 @@ def _create_ddp_master_job(
                 env_secret_mapping=env_secret_mapping,
                 host_network=True,
                 host_aliases=aliases,
-                resources=resources,
+                resources=resource_limits,
                 tolerations=_get_tolerations(role="worker"),
                 volumes=volumes,
                 volume_mounts=mounts,
+                resource_requests=resource_requests,
             )
 
             worker_deployment = resource_allocation.k8s.get_deployment(
@@ -301,7 +304,7 @@ def _create_ddp_master_job(
 @typeguard.typechecked
 def lightning_train_remote(
     worker_image: str,
-    worker_resources: dict,
+    worker_resources: dict[str, int | float | str],
     spec_path: str,
     num_nodes: int = 1,
     retry_count: int = 3,
@@ -310,6 +313,7 @@ def lightning_train_remote(
     worker_cluster_region: Optional[str] = None,
     worker_cluster_project: Optional[str] = None,
     follow_logs: Optional[bool] = False,
+    worker_resource_requests: Optional[dict[str, int | float | str]] = None,
 ) -> None:
     assert num_nodes > 0
     cluster_info = resource_allocation.k8s.parse_cluster_info(
@@ -329,9 +333,10 @@ def lightning_train_remote(
         env_vars=env_vars,
         follow_logs=follow_logs,
         image=worker_image,
-        resources=worker_resources,
+        resource_limits=worker_resources,
         train_spec=spec,
         num_nodes=num_nodes,
         host_network=num_nodes > 1,
         retry_count=retry_count,
+        resource_requests=worker_resource_requests,
     )


### PR DESCRIPTION
Current behavior uses the worker_resources as both, lower and upper bound.
This PR allwos specifying a separate lower bound. (E.g. I want to ensure my process has 1 vCPU, but not throttle it if it goes beyond).

I tried to make it as backward compatible as possible, which is why the old name and argument order is preserved for public methods, but not sure if that causes confusion?