### PR TITLE
chore: typeguard version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ urls = { Homepage = "https://github.com/zettaai/zetta_utils" }
 requires-python = ">3.8,<3.11"
 dependencies = [
     "attrs >= 21.3",
-    "typeguard == 4.1.1",
+    "typeguard == 4.1.5",
     "cachetools >= 5.2.0",
     "fsspec >= 2022.8.2",
     "rich >= 12.6.0",

--- a/zetta_utils/message_queues/base.py
+++ b/zetta_utils/message_queues/base.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, Sequence, TypeVar
 
 import attrs
-from git import Sequence
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Added a bunch of `X | Y` hints in my last PR within a typechecked function that made typeguard unhappy. Version bump fixes it.

Also fixes accidental git import