### PR TITLE
fix: workaround for reading uint32 data

### DIFF
--- a/tests/unit/tensor_ops/test_convert.py
+++ b/tests/unit/tensor_ops/test_convert.py
@@ -48,3 +48,16 @@ def test_to_float(x, expected):
 def test_to_uint(x, expected):
     result = convert.to_uint8(x)
     np.testing.assert_array_equal(result, expected)
+
+
+def test_to_torch_from_uint32():
+    x = np.ones(3).astype(np.uint32)
+    result = convert.to_torch(x)
+    np.testing.assert_array_equal(result, x)
+
+
+def test_to_torch_from_uint32_exc():
+    x = np.ones(3).astype(np.uint32)
+    x[0] = np.uint32(2 ** 31)
+    with pytest.raises(ValueError):
+        convert.to_torch(x)

--- a/zetta_utils/tensor_ops/convert.py
+++ b/zetta_utils/tensor_ops/convert.py
@@ -44,6 +44,11 @@ def to_torch(data: Tensor, device: torch.types.Device = None) -> torch.Tensor:
             if data.max() > np.uint64(2 ** 63 - 1):
                 raise ValueError("Unable to convert uint64 dtype to int64")
             data = data.astype(np.int64)
+        elif data.dtype == np.uint32:
+            if data.max() > np.uint32(2 ** 31 - 1):
+                raise ValueError("Unable to convert uint32 dtype to int32")
+            data = data.astype(np.int32)
+
         result = torch.from_numpy(data).to(device)  # type: ignore # pytorch bug
 
     return result


### PR DESCRIPTION
In the same manner as uint64 because torch doesn't like uint