### PR TITLE
feat: add VolumetricIndexOverrideStartOffset

### DIFF
--- a/tests/unit/layer/volumetric/test_tools.py
+++ b/tests/unit/layer/volumetric/test_tools.py
@@ -2,7 +2,11 @@
 import pytest
 
 from zetta_utils.geometry import BBox3D, IntVec3D, Vec3D
-from zetta_utils.layer.volumetric import VolumetricIndex, VolumetricIndexChunker
+from zetta_utils.layer.volumetric import (
+    VolumetricIndex,
+    VolumetricIndexChunker,
+    VolumetricIndexStartOffsetOverrider,
+)
 
 
 @pytest.mark.parametrize(
@@ -76,3 +80,19 @@ def test_volumetric_index_chunker(
     )
     res = list(vic(idx=idx, stride_start_offset_in_unit=stride_start_offset_in_unit, mode=mode))
     assert res[1].bbox == chunk1
+
+
+@pytest.mark.parametrize(
+    "override_offset, expected_start, expected_stop",
+    [
+        [[7, 8, 9], [7, 8, 9], [17, 18, 19]],
+        [[None, None, 10], [4, 5, 10], [14, 15, 20]],
+        [[None, None, None], [4, 5, 6], [14, 15, 16]],
+    ],
+)
+def test_volumetric_index_offset_overrider(override_offset, expected_start, expected_stop):
+    index = VolumetricIndex(resolution=Vec3D(1, 1, 1), bbox=BBox3D(((4, 14), (5, 15), (6, 16))))
+    visoo = VolumetricIndexStartOffsetOverrider(override_offset=override_offset)
+    index = visoo(index)
+    assert index.start == Vec3D(*expected_start)
+    assert index.stop == Vec3D(*expected_stop)

--- a/zetta_utils/layer/volumetric/__init__.py
+++ b/zetta_utils/layer/volumetric/__init__.py
@@ -15,6 +15,7 @@ from .tools import (
     InvertProcessor,
     VolumetricIndexTranslator,
     VolumetricIndexChunker,
+    VolumetricIndexStartOffsetOverrider,
 )
 from .layer import (
     VolumetricLayer,

--- a/zetta_utils/layer/volumetric/tools.py
+++ b/zetta_utils/layer/volumetric/tools.py
@@ -43,10 +43,10 @@ class VolumetricIndexTranslator:  # pragma: no cover # under 3 statements, no co
         return result
 
 
-@builder.register("VolumetricIndexOverrideStartOffset")
+@builder.register("VolumetricIndexStartOffsetOverrider")
 @typechecked
 @attrs.mutable
-class VolumetricIndexOverrideStartOffset:  # pragma: no cover # under 3 statements, no conditionals
+class VolumetricIndexStartOffsetOverrider:
     override_offset: Sequence[int | None]
 
     def __call__(self, idx: VolumetricIndex) -> VolumetricIndex:

--- a/zetta_utils/layer/volumetric/tools.py
+++ b/zetta_utils/layer/volumetric/tools.py
@@ -7,7 +7,7 @@ import torch
 from typeguard import typechecked
 
 from zetta_utils import builder, log, tensor_ops
-from zetta_utils.geometry import BBoxStrider, Vec3D
+from zetta_utils.geometry import BBoxStrider, IntVec3D, Vec3D
 
 from .. import IndexChunker, JointIndexDataProcessor
 from . import VolumetricIndex
@@ -39,6 +39,25 @@ class VolumetricIndexTranslator:  # pragma: no cover # under 3 statements, no co
             idx=idx,
             offset=self.offset,
             resolution=self.resolution,
+        )
+        return result
+
+
+@builder.register("VolumetricIndexOverrideStartOffset")
+@typechecked
+@attrs.mutable
+class VolumetricIndexOverrideStartOffset:
+    offset: Sequence[float | None]
+
+    def __call__(self, idx: VolumetricIndex) -> VolumetricIndex:
+        start = IntVec3D(
+            *[int(x) if x is not None else int(y) for x, y in zip(self.offset, idx.start)]
+        )
+        stop = start + (idx.stop - idx.start)
+        result = idx.from_coords(
+            start_coord=start.vec,
+            end_coord=stop.vec,
+            resolution=idx.resolution,
         )
         return result
 

--- a/zetta_utils/layer/volumetric/tools.py
+++ b/zetta_utils/layer/volumetric/tools.py
@@ -46,20 +46,19 @@ class VolumetricIndexTranslator:  # pragma: no cover # under 3 statements, no co
 @builder.register("VolumetricIndexOverrideStartOffset")
 @typechecked
 @attrs.mutable
-class VolumetricIndexOverrideStartOffset:
-    offset: Sequence[float | None]
+class VolumetricIndexOverrideStartOffset:  # pragma: no cover # under 3 statements, no conditionals
+    override_offset: Sequence[int | None]
 
     def __call__(self, idx: VolumetricIndex) -> VolumetricIndex:
         start = IntVec3D(
-            *[int(x) if x is not None else int(y) for x, y in zip(self.offset, idx.start)]
+            *[x if x is not None else y for x, y in zip(self.override_offset, idx.start)]
         )
         stop = start + (idx.stop - idx.start)
-        result = idx.from_coords(
+        return VolumetricIndex.from_coords(
             start_coord=start.vec,
             end_coord=stop.vec,
             resolution=idx.resolution,
         )
-        return result
 
 
 @builder.register("DataResolutionInterpolator")


### PR DESCRIPTION
Useful for applying a single 2D section across a 3D volume, e.g., a rotation field.