### PR TITLE
hotfix: use concurrent.futures.ProcessPoolExecutor

### DIFF
--- a/tests/unit/common/test_multiprocessing.py
+++ b/tests/unit/common/test_multiprocessing.py
@@ -16,8 +16,7 @@ def test_run_func(args, expected):
     with setup_persistent_process_pool(3):
         pool = get_persistent_process_pool()
         assert pool is not None
-        future = pool.map(times2, args)
-        assert list(future.result()) == expected
+        assert list(pool.map(times2, args)) == expected
 
 
 def test_no_init_with_1_proc():
@@ -37,7 +36,6 @@ def test_unalloc_nonexistent_exc():
         with setup_persistent_process_pool(2):
             pool = get_persistent_process_pool()
             assert pool is not None
-            pool.stop()
-            pool.join()
+            pool.shutdown()
             zetta_utils.common.multiprocessing.PERSISTENT_PROCESS_POOL = None
         # exception on exiting context

--- a/zetta_utils/common/multiprocessing.py
+++ b/zetta_utils/common/multiprocessing.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 import contextlib
-
-from pebble import ProcessPool
+from concurrent.futures import ProcessPoolExecutor
 
 from zetta_utils import log
 
 logger = log.get_logger("zetta_utils")
 
-PERSISTENT_PROCESS_POOL: ProcessPool | None = None
+PERSISTENT_PROCESS_POOL: ProcessPoolExecutor | None = None
 
 
 @contextlib.contextmanager
@@ -26,7 +25,7 @@ def setup_persistent_process_pool(num_procs: int):
             raise RuntimeError("Persistent process pool already exists.")
         else:
             logger.info(f"Creating a persistent process pool with {num_procs} processes.")
-            PERSISTENT_PROCESS_POOL = ProcessPool(num_procs)
+            PERSISTENT_PROCESS_POOL = ProcessPoolExecutor(num_procs)
         yield
     finally:
         if num_procs == 1:
@@ -34,13 +33,12 @@ def setup_persistent_process_pool(num_procs: int):
         elif PERSISTENT_PROCESS_POOL is None:
             raise RuntimeError("Persistent process pool does not exist.")
         else:
-            PERSISTENT_PROCESS_POOL.stop()
-            PERSISTENT_PROCESS_POOL.join()
+            PERSISTENT_PROCESS_POOL.shutdown()
             PERSISTENT_PROCESS_POOL = None
             logger.info("Cleaned up persistent process pool.")
 
 
-def get_persistent_process_pool() -> ProcessPool | None:
+def get_persistent_process_pool() -> ProcessPoolExecutor | None:
     """
     Fetches and returns either the semaphore associated with the current process,
     or the semaphore associated with the parent process, in that order.

--- a/zetta_utils/mazepa/autoexecute_task_queue.py
+++ b/zetta_utils/mazepa/autoexecute_task_queue.py
@@ -51,13 +51,11 @@ class AutoexecuteTaskQueue(MessageQueue):
                 futures = []
                 for task in self.tasks_todo[:max_num]:
                     futures.append(
-                        pool.schedule(
+                        pool.submit(
                             execute_task,
-                            kwargs={
-                                "task": task,
-                                "debug": self.debug,
-                                "handle_exceptions": self.handle_exceptions,
-                            },
+                            task=task,
+                            debug=self.debug,
+                            handle_exceptions=self.handle_exceptions,
                         )
                     )
                 results = [future.result() for future in futures]


### PR DESCRIPTION
This seems to avoid one process randomly hanging that ``pebble`` has.