### PR TITLE
pytorch-lightning upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ segmentation = ["onnx >= 1.13.0", "onnxruntime-gpu >= 1.13.1"]
 training = [
     "zetta_utils[tensor_ops,cloudvol,convnet,viz,gcs,augmentations]",
     "torch >= 2.0",
-    "pytorch-lightning == 1.7.7",                       # mypy error on newer
+    "pytorch-lightning ~= 2.0.0",  # mp dataloader causes segmentation faults with 2.1.0
     "torchmetrics == 0.11.4",
     "wandb >= 0.13.1",
 ]

--- a/zetta_utils/training/lightning/regimes/alignment/base_encoder.py
+++ b/zetta_utils/training/lightning/regimes/alignment/base_encoder.py
@@ -41,7 +41,7 @@ class BaseEncoderRegime(pl.LightningModule):  # pylint: disable=too-many-ancesto
         optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
         return optimizer
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         log_results(
             "val",
             "worst",

--- a/zetta_utils/training/lightning/regimes/alignment/encoding_coarsener_gen_x1.py
+++ b/zetta_utils/training/lightning/regimes/alignment/encoding_coarsener_gen_x1.py
@@ -43,21 +43,21 @@ class EncodingCoarsenerGenX1Regime(pl.LightningModule):  # pylint: disable=too-m
         optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
         return optimizer
 
-    @staticmethod
-    def log_results(mode: str, title_suffix: str = "", **kwargs):
-        wandb.log(
-            {
-                f"results/{mode}_{title_suffix}_slider": [
-                    wandb.Image(viz.rendering.Renderer()(v.squeeze()), caption=k)
-                    for k, v in kwargs.items()
-                ]
-            }
+    def log_results(self, mode: str, title_suffix: str = "", **kwargs):
+        if not self.logger:
+            return
+        self.logger.log_image(
+            f"results/{mode}_{title_suffix}_slider",
+            images=[
+                wandb.Image(viz.rendering.Renderer()(v.squeeze()), caption=k)
+                for k, v in kwargs.items()
+            ],
         )
 
     def validation_epoch_start(self, _):
         seed_everything(42)
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         self.log_results(
             "val",
             "worst",

--- a/zetta_utils/training/lightning/regimes/alignment/encoding_coarsener_highres.py
+++ b/zetta_utils/training/lightning/regimes/alignment/encoding_coarsener_highres.py
@@ -90,20 +90,18 @@ class EncodingCoarsenerHighRes(pl.LightningModule):  # pylint: disable=too-many-
         if self.decoder_ckpt_path is not None:
             convnet.utils.load_weights_file(self, self.decoder_ckpt_path, ["decoder"])
 
-    @staticmethod
-    def log_results(mode: str, title_suffix: str = "", **kwargs):
-        wandb.log(
-            {
-                f"results/{mode}_{title_suffix}_slider": [
-                    wandb.Image(v.squeeze(), caption=k) for k, v in kwargs.items()
-                ]
-            }
+    def log_results(self, mode: str, title_suffix: str = "", **kwargs):
+        if not self.logger:
+            return
+        self.logger.log_image(
+            f"results/{mode}_{title_suffix}_slider",
+            images=[wandb.Image(v.squeeze(), caption=k) for k, v in kwargs.items()],
         )
         # images = torchvision.utils.make_grid([img[0] for img, _ in img_spec])
         # caption = ",".join(cap for _, cap in img_spec) + title_suffix
         # wandb.log({f"results/{mode}_row": [wandb.Image(images, caption)]})
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         self.log_results(
             "val",
             "worst",

--- a/zetta_utils/training/lightning/regimes/alignment/minima_encoder.py
+++ b/zetta_utils/training/lightning/regimes/alignment/minima_encoder.py
@@ -37,18 +37,18 @@ class MinimaEncoderRegime(pl.LightningModule):  # pylint: disable=too-many-ances
         optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
         return optimizer
 
-    @staticmethod
-    def log_results(mode: str, title_suffix: str = "", **kwargs):
-        wandb.log(
-            {
-                f"results/{mode}_{title_suffix}_slider": [
-                    wandb.Image(viz.rendering.Renderer()(v.squeeze()), caption=k)
-                    for k, v in kwargs.items()
-                ]
-            }
+    def log_results(self, mode: str, title_suffix: str = "", **kwargs):
+        if not self.logger:
+            return
+        self.logger.log_image(
+            f"results/{mode}_{title_suffix}_slider",
+            images=[
+                wandb.Image(viz.rendering.Renderer()(v.squeeze()), caption=k)
+                for k, v in kwargs.items()
+            ],
         )
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         self.log_results(
             "val",
             "worst",

--- a/zetta_utils/training/lightning/regimes/alignment/misalignment_detector.py
+++ b/zetta_utils/training/lightning/regimes/alignment/misalignment_detector.py
@@ -45,20 +45,18 @@ class MisalignmentDetectorRegime(pl.LightningModule):  # pylint: disable=too-man
         field_norm = (field_i ** 2 + field_j ** 2) ** 0.5
         return torch.clamp(field_norm, 0, threshold)
 
-    @staticmethod
-    def log_results(mode: str, title_suffix: str = "", **kwargs):
-        wandb.log(
-            {
-                f"results/{mode}_{title_suffix}_slider": [
-                    wandb.Image(v.squeeze(), caption=k) for k, v in kwargs.items()
-                ]
-            }
+    def log_results(self, mode: str, title_suffix: str = "", **kwargs):
+        if not self.logger:
+            return
+        self.logger.log_image(
+            f"results/{mode}_{title_suffix}_slider",
+            images=[wandb.Image(v.squeeze(), caption=k) for k, v in kwargs.items()],
         )
         # images = torchvision.utils.make_grid([img[0] for img, _ in img_spec])
         # caption = ",".join(cap for _, cap in img_spec) + title_suffix
         # wandb.log({f"results/{mode}_row": [wandb.Image(images, caption)]})
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         self.log_results(
             "val",
             "worst",

--- a/zetta_utils/training/lightning/regimes/alignment/misalignment_detector_aced.py
+++ b/zetta_utils/training/lightning/regimes/alignment/misalignment_detector_aced.py
@@ -49,8 +49,9 @@ class MisalignmentDetectorAcedRegime(pl.LightningModule):  # pylint: disable=too
         optimizer = torch.optim.Adam(self.model.parameters(), lr=self.lr)
         return optimizer
 
-    @staticmethod
-    def log_results(mode: str, title_suffix: str = "", **kwargs):
+    def log_results(self, mode: str, title_suffix: str = "", **kwargs):
+        if not self.logger:
+            return
         images = []
         for k, v in kwargs.items():
             for b in range(1):
@@ -100,12 +101,12 @@ class MisalignmentDetectorAcedRegime(pl.LightningModule):  # pylint: disable=too
                         )
                     )
 
-        wandb.log({f"results/{mode}_{title_suffix}_slider": images})
+        self.logger.log_image(f"results/{mode}_{title_suffix}_slider", images=images)
 
     def validation_epoch_start(self, _):  # pylint: disable=no-self-use
         seed_everything(42)
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         self.log_results(
             "val",
             "worst",

--- a/zetta_utils/training/lightning/regimes/common.py
+++ b/zetta_utils/training/lightning/regimes/common.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import wandb
+from pytorch_lightning.loggers.logger import Logger
 
 from zetta_utils import viz
 
@@ -9,13 +12,16 @@ def is_2d_image(tensor):
     )
 
 
-def log_results(mode: str, title_suffix: str = "", **kwargs):
+def log_results(mode: str, title_suffix: str = "", logger: Logger | None = None, **kwargs):
     if all(is_2d_image(v) for v in kwargs.values()):
         row = [
             wandb.Image(viz.rendering.Renderer()(v.squeeze()), caption=k)
             for k, v in kwargs.items()
         ]
-        wandb.log({f"results/{mode}_{title_suffix}_slider": row})
+        if logger is None:
+            wandb.log({f"results/{mode}_{title_suffix}_slider": row})
+        else:
+            logger.log_image(f"results/{mode}_{title_suffix}_slider", images=row)
     else:
         max_z = max(v.shape[-1] for v in kwargs.values())
 
@@ -29,4 +35,7 @@ def log_results(mode: str, title_suffix: str = "", **kwargs):
 
                 row.append(wandb.Image(rendered, caption=k))
 
-            wandb.log({f"results/{mode}_{title_suffix}_slider_z{z}": row})
+            if logger is None:
+                wandb.log({f"results/{mode}_{title_suffix}_slider_z{z}": row})
+            else:
+                logger.log_image(f"results/{mode}_{title_suffix}_slider_z{z}", images=row)

--- a/zetta_utils/training/lightning/regimes/naive_supervised.py
+++ b/zetta_utils/training/lightning/regimes/naive_supervised.py
@@ -29,7 +29,7 @@ class NaiveSupervisedRegime(pl.LightningModule):
     def validation_epoch_start(self, _):
         seed_everything(42)
 
-    def validation_epoch_end(self, _):
+    def on_validation_epoch_end(self):
         seed_everything(None)
 
     def validation_step(self, batch, batch_idx):

--- a/zetta_utils/training/lightning/train.py
+++ b/zetta_utils/training/lightning/train.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Final, List, Optional
 import pytorch_lightning as pl
 import torch
 import typeguard
+from lightning_fabric.utilities.cloud_io import get_filesystem
 from pytorch_lightning.strategies import ddp
-from pytorch_lightning.utilities.cloud_io import get_filesystem
 from torch.distributed.launcher import api as torch_launcher_api
 
 from kubernetes import client as k8s_client  # type: ignore
@@ -28,6 +28,10 @@ REQUIRED_ENV_VARS: Final = [
     "ZETTA_PROJECT",
     "WANDB_API_KEY",
 ]
+
+
+def distributed_available() -> bool:
+    return torch.distributed.is_available() and torch.distributed.is_initialized()
 
 
 @builder.register("lightning_train")
@@ -65,7 +69,7 @@ def lightning_train(
         logger.warning("Invoked without builder: Unable to save configuration.")
 
     if full_state_ckpt_path == "last":
-        if get_filesystem(trainer.ckpt_path).exists(trainer.ckpt_path):  # type: ignore
+        if get_filesystem(trainer.ckpt_path).exists(trainer.ckpt_path):
             ckpt_path = trainer.ckpt_path
         else:
             ckpt_path = None


### PR DESCRIPTION
Had to disable multiprocessing for the jit/onnx export to work at all. I don't think it's a big slowdown - depends on the validation intervall, of course.

Upgrade is probably a good idea anyway, but main reason is the newer pytorch-lightning gave more reliable exceptions when testing DDP (and there may be a chance it fixes bugs with DDP we are unaware of).

Necessary changes in more detail:
* `validation_epoch_end` is now `on_validation_epoch_end` and has no return type
* `pytorch_lightning.utilities.distributed import distributed_available` was removed - it's was a one-liner I added to zetta_utils
* `pytorch_lightning.utilities.cloud_io` was moved to `lighning_fabric.utilities.cloud_io` (and got typings!)
* `pl.callbacks` is intialized later, which caused mypy to complain in our init. I moved the progress and checkpointing callbacks around to get initialized properly with the other PL stuff. `ConfigureTraceCallback` remains a special case, though :(
* Like mentioned above, had to disable the multiprocessing, otherwise the newly spawned process would attempt to login to wandb again and crash... but `fork` doesn't work with PyTorch
* some changes to how the TraceCallback collects the submodule names (`named_children()` rather than iterating through the attributes)