### PR TITLE
DDP fixes

### DIFF
--- a/zetta_utils/training/lightning/train.py
+++ b/zetta_utils/training/lightning/train.py
@@ -267,14 +267,17 @@ def _create_ddp_master_job(
         if num_nodes > 1:
             train_pod = resource_allocation.k8s.get_job_pod(train_job, cluster_info)
             aliases = [k8s_client.V1HostAlias(hostnames=["master"], ip=train_pod.status.host_ip)]
-            worker_role_env = k8s_client.V1EnvVar(name="MY_ROLE", value="worker")
+            worker_env = [
+                k8s_client.V1EnvVar(name="MY_ROLE", value="worker"),
+                k8s_client.V1EnvVar(name="MASTER_ADDR", value="master"),
+            ]
 
             worker_pod_spec = resource_allocation.k8s.get_pod_spec(
                 name="workers",
                 image=image,
                 command=["/bin/bash"],
                 command_args=["-c", zetta_cmd],
-                envs=envs + [worker_role_env],
+                envs=envs + worker_env,
                 env_secret_mapping=env_secret_mapping,
                 host_network=True,
                 host_aliases=aliases,

--- a/zetta_utils/training/lightning/trainers/default.py
+++ b/zetta_utils/training/lightning/trainers/default.py
@@ -94,6 +94,11 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
             id=f"{experiment_version}.{self.global_rank}",
         )
 
+        self.trace_configuration: Dict = {}
+
+        # self.callbacks will exist at runtime
+        self.callbacks.append(ConfigureTraceCallback(self))  # type: ignore
+
         if self.global_rank != 0:
             return
 
@@ -101,8 +106,6 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
             this_dir = os.path.dirname(os.path.abspath(__file__))
             zetta_root_path = f"{this_dir}/../../.."
             self.logger.experiment.log_code(zetta_root_path)
-
-        self.trace_configuration: Dict = {}
 
         def log_config(config):
             if experiment_version.startswith("tmp"):
@@ -114,9 +117,6 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
                 logger.info("Saved training configuration.")
 
         self.log_config = log_config
-
-        # self.callbacks will exist at runtime
-        self.callbacks.append(ConfigureTraceCallback(self))  # type: ignore
 
         # Due to a bug in PL we're unable to use normal methods
         # to resume training with ckpt_path='last' when storing

--- a/zetta_utils/training/lightning/trainers/default.py
+++ b/zetta_utils/training/lightning/trainers/default.py
@@ -70,13 +70,7 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
             api_key = os.environ.get("WANDB_API_KEY", None)
             wandb.login(key=api_key)
 
-        pid = os.getpid()
-        kwargs["logger"] = WandbLogger(
-            project=experiment_name,
-            group=f"{experiment_name}.{experiment_version}",
-            name=f"{experiment_version}",
-            id=f"{experiment_version}.{pid}",
-        )
+        kwargs["logger"] = False
 
         log_dir = os.path.join(
             kwargs.get("default_root_dir", os.getcwd()),
@@ -92,6 +86,13 @@ class ZettaDefaultTrainer(pl.Trainer):  # pragma: no cover
         )
 
         super().__init__(*args, **kwargs)
+
+        self.logger = WandbLogger(
+            project=experiment_name,
+            group=f"{experiment_name}.{experiment_version}",
+            name=f"{experiment_version}",
+            id=f"{experiment_version}.{self.global_rank}",
+        )
 
         if self.global_rank != 0:
             return


### PR DESCRIPTION
* added @akhileshh's suggestion for the main node address.
* found a way to name the WandbLogger runs based on their global rank
* fixed a bug I introduced in the last PR: each DDP device must perform the exact same set of operations, otherwise you get `CollectiveFingerPrint` mismatches. More specifically: All devices must run the TraceCallback once, even if it's the exact same result and only rank 0 writes the checkpoint.