### PR TITLE
feat(train): adds node_selectors based on provision_model

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -61,7 +61,7 @@ jobs:
         run: pip install -e '.[modules, test]'
       - name: Install CUE
         if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
-        run: go install cuelang.org/go/cmd/cue@latest
+        run: go install cuelang.org/go/cmd/cue@v0.6.0
       - name: Run pytest
         if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
         run: coverage run -m py.test ./tests/unit

--- a/.github/workflows/testing_integration.yaml
+++ b/.github/workflows/testing_integration.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Python dependencies
         run: pip install -e '.[modules, test]'
       - name: Install CUE
-        run: go install cuelang.org/go/cmd/cue@latest
+        run: go install cuelang.org/go/cmd/cue@v0.6.0
       - name: Run pytest
         run: cd tests/integration && coverage run -m pytest --run-integration .
       - name: Send coverage repot to codecov

--- a/zetta_utils/cloud_management/resource_allocation/k8s/__init__.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/__init__.py
@@ -24,3 +24,4 @@ from .job import (
 from .pod import get_pod_spec
 from .secret import secrets_ctx_mngr, get_secrets_and_mapping
 from .service import get_service, service_ctx_manager
+from .volume import get_common_volumes, get_common_volume_mounts

--- a/zetta_utils/cloud_management/resource_allocation/k8s/deployment.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/deployment.py
@@ -19,6 +19,7 @@ from ..resource_tracker import (
 from .common import ClusterInfo, get_cluster_data, get_mazepa_worker_command
 from .pod import get_pod_spec
 from .secret import secrets_ctx_mngr
+from .volume import get_common_volume_mounts, get_common_volumes
 
 logger = log.get_logger("zetta_utils")
 
@@ -101,18 +102,6 @@ def get_mazepa_worker_deployment(  # pylint: disable=too-many-locals
     )
     logger.debug(f"Making a deployment with worker command: '{worker_command}'")
 
-    dshm = k8s_client.V1Volume(
-        name="dshm", empty_dir=k8s_client.V1EmptyDirVolumeSource(medium="Memory")
-    )
-    tmp = k8s_client.V1Volume(
-        name="tmp", empty_dir=k8s_client.V1EmptyDirVolumeSource(medium="Memory")
-    )
-    volumes = [dshm, tmp]
-    volume_mounts = [
-        k8s_client.V1VolumeMount(mount_path="/dev/shm", name="dshm"),
-        k8s_client.V1VolumeMount(mount_path="/tmp", name="tmp"),
-    ]
-
     return get_deployment_spec(
         name=execution_id,
         image=image,
@@ -121,8 +110,8 @@ def get_mazepa_worker_deployment(  # pylint: disable=too-many-locals
         resources=resources,
         labels=labels_final,
         env_secret_mapping=env_secret_mapping,
-        volumes=volumes,
-        volume_mounts=volume_mounts,
+        volumes=get_common_volumes(),
+        volume_mounts=get_common_volume_mounts(),
         resource_requests=resource_requests,
     )
 

--- a/zetta_utils/cloud_management/resource_allocation/k8s/deployment.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/deployment.py
@@ -5,7 +5,7 @@ Helpers for k8s deployments.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from kubernetes import client as k8s_client  # type: ignore
 from zetta_utils import builder, log
@@ -35,6 +35,7 @@ def get_deployment_spec(
     volumes: Optional[List[k8s_client.V1Volume]] = None,
     volume_mounts: Optional[List[k8s_client.V1VolumeMount]] = None,
     resource_requests: Optional[Dict[str, int | float | str]] = None,
+    provisioning_model: Literal["standard", "spot"] = "spot",
 ) -> k8s_client.V1Deployment:
     schedule_toleration = k8s_client.V1Toleration(
         key="worker-pool", operator="Equal", value="true", effect="NoSchedule"
@@ -47,6 +48,7 @@ def get_deployment_spec(
         command_args=["-c", command],
         resources=resources,
         env_secret_mapping=env_secret_mapping,
+        node_selector={"cloud.google.com/gke-provisioning": provisioning_model},
         tolerations=[schedule_toleration],
         volumes=volumes,
         volume_mounts=volume_mounts,
@@ -91,6 +93,7 @@ def get_mazepa_worker_deployment(  # pylint: disable=too-many-locals
     resource_requests: Optional[Dict[str, int | float | str]] = None,
     num_procs: int = 1,
     semaphores_spec: dict[SemaphoreType, int] | None = None,
+    provisioning_model: Literal["standard", "spot"] = "spot",
 ):
     if labels is None:
         labels_final = {"execution_id": execution_id}
@@ -113,6 +116,7 @@ def get_mazepa_worker_deployment(  # pylint: disable=too-many-locals
         volumes=get_common_volumes(),
         volume_mounts=get_common_volume_mounts(),
         resource_requests=resource_requests,
+        provisioning_model=provisioning_model,
     )
 
 

--- a/zetta_utils/cloud_management/resource_allocation/k8s/volume.py
+++ b/zetta_utils/cloud_management/resource_allocation/k8s/volume.py
@@ -1,0 +1,24 @@
+"""
+Helpers for k8s volumes.
+"""
+
+from __future__ import annotations
+
+from kubernetes import client as k8s_client  # type: ignore
+
+
+def get_common_volumes():
+    dshm = k8s_client.V1Volume(
+        name="dshm", empty_dir=k8s_client.V1EmptyDirVolumeSource(medium="Memory")
+    )
+    tmp = k8s_client.V1Volume(
+        name="tmp", empty_dir=k8s_client.V1EmptyDirVolumeSource(medium="Memory")
+    )
+    return [dshm, tmp]
+
+
+def get_common_volume_mounts():
+    return [
+        k8s_client.V1VolumeMount(mount_path="/dev/shm", name="dshm"),
+        k8s_client.V1VolumeMount(mount_path="/tmp", name="tmp"),
+    ]

--- a/zetta_utils/mazepa_addons/configurations/execute_on_gcp_with_sqs.py
+++ b/zetta_utils/mazepa_addons/configurations/execute_on_gcp_with_sqs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import os
 from contextlib import AbstractContextManager, ExitStack
-from typing import Dict, Final, Iterable, Optional, Union
+from typing import Dict, Final, Iterable, Literal, Optional, Union
 
 from zetta_utils import builder, log, mazepa
 from zetta_utils.cloud_management import execution_tracker, resource_allocation
@@ -62,6 +62,7 @@ def get_gcp_with_sqs_config(
     worker_resource_requests: Optional[Dict[str, int | float | str]] = None,
     num_procs: int = 1,
     semaphores_spec: dict[SemaphoreType, int] | None = None,
+    provisioning_model: Literal["standard", "spot"] = "spot",
 ) -> tuple[PushMessageQueue[Task], PullMessageQueue[OutcomeReport], list[AbstractContextManager]]:
     work_queue_name = f"zzz-{execution_id}-work"
     outcome_queue_name = f"zzz-{execution_id}-outcome"
@@ -101,6 +102,7 @@ def get_gcp_with_sqs_config(
         resource_requests=worker_resource_requests,
         num_procs=num_procs,
         semaphores_spec=semaphores_spec,
+        provisioning_model=provisioning_model,
     )
 
     ctx_managers.append(
@@ -137,6 +139,7 @@ def execute_on_gcp_with_sqs(  # pylint: disable=too-many-locals
     worker_resource_requests: Optional[Dict[str, int | float | str]] = None,
     num_procs: int = 1,
     semaphores_spec: dict[SemaphoreType, int] | None = None,
+    provisioning_model: Literal["standard", "spot"] = "spot",
 ):
     _ensure_required_env_vars()
     execution_id = mazepa.id_generation.get_unique_id(
@@ -182,6 +185,7 @@ def execute_on_gcp_with_sqs(  # pylint: disable=too-many-locals
             worker_resource_requests=worker_resource_requests,
             num_procs=num_procs,
             semaphores_spec=semaphores_spec,
+            provisioning_model=provisioning_model,
         )
 
     with ExitStack() as stack:

--- a/zetta_utils/training/lightning/train.py
+++ b/zetta_utils/training/lightning/train.py
@@ -239,7 +239,10 @@ def _get_tolerations() -> List[k8s_client.V1Toleration]:
     gpu = k8s_client.V1Toleration(
         key="nvidia.com/gpu", operator="Equal", value="present", effect="NoSchedule"
     )
-    return [gpu]
+    worker = k8s_client.V1Toleration(
+        key="worker-pool", operator="Equal", value="true", effect="NoSchedule"
+    )
+    return [gpu, worker]
 
 
 def _spec_configmap_vol_and_ctx(


### PR DESCRIPTION
Also moved creation of `dshm` and `tmp` volumes because they were repeated, and pylint was complaining about having too many statements in `_lightning_train_remote`