### PR TITLE
feat(compute_field_flow): Add missing expand_bbox options

### DIFF
--- a/zetta_utils/mazepa_layer_processing/alignment/compute_field_flow.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/compute_field_flow.py
@@ -141,6 +141,8 @@ class ComputeFieldFlowSchema:
     ] = "linear"
     level_intermediaries_dirs: Sequence[str | None] | None = None
     max_reduction_chunk_sizes: Sequence[int] | Sequence[Sequence[int]] | None = None
+    expand_bbox_resolution: bool = False
+    expand_bbox_backend: bool = False
     expand_bbox_processing: bool = False
     shrink_processing_chunk: bool = False
 
@@ -177,6 +179,8 @@ class ComputeFieldFlowSchema:
             processing_crop_pads=self.processing_crop_pads,
             processing_blend_pads=self.processing_blend_pads,
             processing_blend_modes=self.processing_blend_modes,
+            expand_bbox_resolution=self.expand_bbox_resolution,
+            expand_bbox_backend=self.expand_bbox_backend,
             expand_bbox_processing=self.expand_bbox_processing,
             shrink_processing_chunk=self.shrink_processing_chunk,
             max_reduction_chunk_sizes=self.max_reduction_chunk_sizes,

--- a/zetta_utils/mazepa_layer_processing/alignment/compute_field_multistage_flow.py
+++ b/zetta_utils/mazepa_layer_processing/alignment/compute_field_multistage_flow.py
@@ -36,6 +36,8 @@ class ComputeFieldStage:
     ] = "linear"
     level_intermediaries_dirs: Sequence[str | None] | None = None
     max_reduction_chunk_sizes: Sequence[int] | Sequence[Sequence[int]] | None = None
+    expand_bbox_resolution: bool = False
+    expand_bbox_backend: bool = False
     expand_bbox_processing: bool = False
     shrink_processing_chunk: bool = False
 
@@ -181,6 +183,8 @@ class ComputeFieldMultistageFlowSchema:
                 processing_crop_pads=stage.processing_crop_pads,
                 processing_blend_pads=stage.processing_blend_pads,
                 processing_blend_modes=stage.processing_blend_modes,
+                expand_bbox_resolution=stage.expand_bbox_resolution,
+                expand_bbox_backend=stage.expand_bbox_backend,
                 expand_bbox_processing=stage.expand_bbox_processing,
                 shrink_processing_chunk=stage.shrink_processing_chunk,
                 max_reduction_chunk_sizes=stage.max_reduction_chunk_sizes,


### PR DESCRIPTION
Needed `expand_bbox_resolution` for some of the recent encoder+misd preparation specs, which wasn't passed to the subchunkable flow so far.