### PR TITLE
feat(train): start remote GPU training from instance without GPU

### DIFF
--- a/zetta_utils/convnet/utils.py
+++ b/zetta_utils/convnet/utils.py
@@ -90,7 +90,9 @@ def load_weights_file(
         return model
 
     with fsspec.open(ckpt_path) as f:
-        loaded_state_raw = torch.load(f)["state_dict"]
+        # Scheduler might not have GPU, but will still attempt to load model weights
+        map_location = "cpu" if not torch.cuda.is_available() else None
+        loaded_state_raw = torch.load(f, map_location=map_location)["state_dict"]
         if component_names is None:
             loaded_state = loaded_state_raw
         elif remove_component_prefix:

--- a/zetta_utils/training/lightning/train.py
+++ b/zetta_utils/training/lightning/train.py
@@ -298,7 +298,7 @@ def _lightning_train_remote(
     Creates a volume mount for `train.cue` in `/opt/zetta_utils/specs`.
     Runs the command `zetta run specs/train.cue` on one or more worker pods.
     """
-    if train_args["trainer"]["accelerator"] == "gpu":
+    if train_args["trainer"]["accelerator"] in ("gpu", "cuda", "auto"):
         num_devices = int(resource_limits["nvidia.com/gpu"])  # type: ignore
         trainer_devices = train_args["trainer"]["devices"]
         if (


### PR DESCRIPTION
The CPU scheduler node might still fail to load the weights file during initialization, e.g. if it contains unsupported data types. This may be a scenario where we just want to skip the sanity checks on scheduler side entirely...