### PR TITLE
hotfix: remove dynamic intermediaries for top level, fix doc examples

### DIFF
--- a/docs/source/subchunkable_apply_flow_quick_start_guide.rst
+++ b/docs/source/subchunkable_apply_flow_quick_start_guide.rst
@@ -671,7 +671,7 @@ With the changes, the example above becomes:
       bbox: #BBOX
 
       // What resolution is our destination?
-      dst_resolution: [4, 4, 45]
+      dst_resolution: [16, 16, 40]
 
       // How do we chunk/crop/blend? List of lists for subchunking.
       processing_chunk_sizes: [[1024, 1024, 1], [256, 256, 1]]
@@ -733,7 +733,7 @@ Each level can have its own crop and blend (as well as ``blend_mode``), but ther
       bbox: #BBOX
 
       // What resolution is our destination?
-      dst_resolution: [4, 4, 45]
+      dst_resolution: [16, 16, 40]
 
       // How do we chunk/crop/blend? List of lists for subchunking.
       // Note that 1024 + 96 * 2 + 32 * 2 = 1280 is evenly divisible by 256.
@@ -821,7 +821,7 @@ To modify the CUE file, we change ``mazepa.execute`` to ``mazepa.execute_on_gcp_
       bbox: #BBOX
 
       // What resolution is our destination?
-      dst_resolution: [4, 4, 45]
+      dst_resolution: [16, 16, 40]
 
       // How do we chunk/crop/blend? List of lists for subchunking.
       // Note that 1024 + 96 * 2 + 32 * 2 = 1280 is evenly divisible by 256.

--- a/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
@@ -884,7 +884,7 @@ def _build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg
             ),
             allow_cache=(allow_cache_up_to_level >= level + 1),
             clear_cache_on_return=(allow_cache_up_to_level == level + 1),
-            force_intermediaries=not (skip_intermediaries) and ((level != num_levels - 1)),
+            force_intermediaries=not (skip_intermediaries),
         )
 
     return flow_schema(idx, dst, op_args, op_kwargs)


### PR DESCRIPTION
Removing dynamically skipped intermediaries for the top level until I can write the lookahead logic for skipping as many levels as possible correctly.