### PR TITLE
hotfix: build list/dict of BuilderPartial objects

### DIFF
--- a/zetta_utils/builder/build.py
+++ b/zetta_utils/builder/build.py
@@ -133,7 +133,9 @@ def _build_dict(**kwargs):
 
 
 def _is_basic(obj) -> bool:
-    return isinstance(obj, (int, float, bool, str, dict, list, tuple)) or obj is None
+    return (
+        isinstance(obj, (int, float, bool, str, dict, list, tuple, BuilderPartial)) or obj is None
+    )
 
 
 def _parse_stages(spec: JsonSerializableValue, name_prefix: str, version: str) -> list[Stage]:


### PR DESCRIPTION
* fixes `zu.builder.build([{"@type": "to_uint8", "@mode": "partial"}]` returning an empty list
* fixes `dill.dumps(zu.builder.build([{"@type": "to_uint8", "@mode": "partial"}]), recurse=True` failing with `RuntimeError: _SafeQueue objects should only be shared between processes through inheritance`
----

* **not** fixed: `zetta run -p` will still fail for complex flows with e.g. `PicklingError: Can't pickle <function concurrent_flow at 0x7fe514f87f70>: it's not the same object as zetta_utils.mazepa.flows.concurrent_flow`