### PR TITLE
fix(testing_integration): resolve LFS pointers

### DIFF
--- a/.github/workflows/testing_integration.yaml
+++ b/.github/workflows/testing_integration.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout from GitHub
         uses: actions/checkout@v4
         with:
-          lfs: 'false'
+          lfs: true
           submodules: true
           ssh-key: ${{ secrets.git_ssh_key  }}
           token: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
The `orjson.JSONDecodeError` occured because the LFS pointers were not converted - so zutils attempted to read the pointers rather than the actual file content.
The integration tests still fail, but the first subchunkable tests are now passing again: https://github.com/ZettaAI/zetta_utils/actions/runs/7709264157/job/21010085787