### PR TITLE
fix(ReduceByWeightedSum): rounding for integer layers

### DIFF
--- a/tests/integration/assets/outputs_ref/test_uint8_copy_auto_divisibility/128_128_40/2048-3072_2048-3072_2000-2001.gz
+++ b/tests/integration/assets/outputs_ref/test_uint8_copy_auto_divisibility/128_128_40/2048-3072_2048-3072_2000-2001.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b103d2c8e79941dd3b594bbd755ad148a6ce0d77f33cc695fd8e13e11f0a9be
-size 26019
+oid sha256:d14ad218ffcc45d5adc3f6adbf961d8bb543fe94634c6061546f11ac846dcb7a
+size 25899


### PR DESCRIPTION
Should resolve the failing integration test `uint8_copy_writeproc_multilevel_checkerboard` and weird Mandala artifacts in blended uint8 layers.

The backend layer data type was used causing truncation errors with every additional blended layer if the destination is using integer

