### PR TITLE
fix(subchunkable_apply_flow): generate deterministic flow_id

### DIFF
--- a/zetta_utils/mazepa/id_generation.py
+++ b/zetta_utils/mazepa/id_generation.py
@@ -36,11 +36,21 @@ def get_unique_id(
 
 
 def generate_invocation_id(
-    fn: Callable,
-    args: list,
-    kwargs: dict,
+    fn: Optional[Callable] = None,
+    args: Optional[list] = None,
+    kwargs: Optional[dict] = None,
     prefix: Optional[str] = None,
-):
+) -> str:
+    """Generate a unique and deterministic ID for a function invocation.
+    The ID is generated using xxhash and dill to hash the function and its arguments.
+
+    :param fn: the function, or really any Callable, defaults to None
+    :param args: the function arguments, or any list, defaults to None
+    :param kwargs: the function kwargs, or any dict, defaults to None
+    :param prefix: optional prefix str, separated by `-`, defaults to None
+    :return: A unique, yet deterministic string that identifies (fn, args, kwargs) in
+      the current Python environment.
+    """
     x = xxhash.xxh128()
     try:
         x.update(

--- a/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/subchunkable_apply_flow.py
@@ -846,11 +846,10 @@ def _build_subchunkable_apply_flow(  # pylint: disable=keyword-arg-before-vararg
             op_kwargs=op_kwargs,
         )
     """
-    Generate flow id for deconflicting intermediaries
+    Generate flow id for deconflicting intermediaries - must be deterministic for proper
+    identification across Python sessions
     """
-    flow_id = id_generation.get_unique_id(
-        prefix="subchunkable", slug_len=4, add_uuid=False, max_len=50
-    )
+    flow_id = id_generation.generate_invocation_id(kwargs=locals(), prefix="subchunkable")
 
     """
     Basic building blocks where the work gets done, at the very bottom


### PR DESCRIPTION
* made `generate_invocation_id` a bit more lenient regarding input parameter types... it doesn't really care about what objects go in, they all get serialized as a tuple
* added dedicated subchunkable flow test (with level intermediaries) to test_id_generation - it's one of the main objects used
* made the suggested change to identify the subchunkable_apply_flow based on its local variables