### PR TITLE
feat: add pad_center_to() wrapping torch.pad()

### DIFF
--- a/tests/unit/tensor_ops/test_common.py
+++ b/tests/unit/tensor_ops/test_common.py
@@ -773,3 +773,105 @@ def test_supports_dict():
     expected_dict = {"ndarray": expected_np, "torch": torch.Tensor(expected_np)}
 
     assert f(in_dict, 1) == expected_dict
+
+
+@pytest.mark.parametrize(
+    "data, shape, mode, value, expected",
+    [
+        [
+            np.ones((1, 3, 3)),
+            (2, 5, 5),
+            "constant",
+            1.0,
+            np.ones((2, 5, 5)),
+        ],
+        [
+            np.ones((1, 3, 3)),
+            (2, 4, 4),
+            "constant",
+            1.0,
+            np.ones((2, 4, 4)),
+        ],
+        [
+            np.ones((1, 3, 3)),
+            (1, 3, 3),
+            "constant",
+            1.0,
+            np.ones((1, 3, 3)),
+        ],
+        [
+            np.array([1, 2, 3]),
+            (4,),
+            "constant",
+            42,
+            np.array([42, 1, 2, 3]),
+        ],
+        [
+            np.array([1, 2, 3]),
+            (5,),
+            "constant",
+            42,
+            np.array([42, 1, 2, 3, 42]),
+        ],
+        [
+            np.array([1, 2, 3]),
+            (6,),
+            "constant",
+            42,
+            np.array([42, 42, 1, 2, 3, 42]),
+        ],
+        [
+            np.array([1, 2, 3]),
+            (6,),
+            "constant",
+            None,
+            np.array([0, 0, 1, 2, 3, 0]),
+        ],
+    ],
+)
+def test_pad_center_to_simple(data, shape, mode, value, expected):
+    result = common.pad_center_to(data, shape=shape, mode=mode, value=value)
+    assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "data, shape, mode, value, expected",
+    [
+        [
+            np.array(
+                [[[1, 2, 3], [4, 5, 6]]],
+            ),
+            (4, 6),
+            "replicate",
+            None,
+            np.array(
+                [[[1, 1, 1, 2, 3, 3], [1, 1, 1, 2, 3, 3], [4, 4, 4, 5, 6, 6], [4, 4, 4, 5, 6, 6]]]
+            ),
+        ],
+        [
+            np.array(
+                [[[1, 2, 3], [4, 5, 6]]],
+            ),
+            (4, 6),
+            "reflect",
+            None,
+            np.array(
+                [[[6, 5, 4, 5, 6, 5], [3, 2, 1, 2, 3, 2], [6, 5, 4, 5, 6, 5], [3, 2, 1, 2, 3, 2]]]
+            ),
+        ],
+        [
+            np.array(
+                [[[1, 2, 3], [4, 5, 6]]],
+            ),
+            (4, 6),
+            "circular",
+            None,
+            np.array(
+                [[[5, 6, 4, 5, 6, 4], [2, 3, 1, 2, 3, 1], [5, 6, 4, 5, 6, 4], [2, 3, 1, 2, 3, 1]]]
+            ),
+        ],
+    ],
+)
+def test_pad_center_to_complex(data, shape, mode, value, expected):
+    result = common.pad_center_to(data, shape=shape, mode=mode, value=value)
+    assert_array_equal(result, expected)

--- a/zetta_utils/tensor_ops/__init__.py
+++ b/zetta_utils/tensor_ops/__init__.py
@@ -10,6 +10,7 @@ from .common import (
     squeeze,
     unsqueeze,
     unsqueeze_to,
+    pad_center_to,
 )
 from .convert import astype, to_np, to_torch
 from .label import get_disp_pair, seg_to_aff, seg_to_rgb

--- a/zetta_utils/tensor_ops/common.py
+++ b/zetta_utils/tensor_ops/common.py
@@ -646,3 +646,36 @@ def abs(  # pylint: disable=redefined-builtin
         return data.abs()
     else:
         return np.abs(data)
+
+
+@builder.register("pad_center_to")
+@typechecked
+@supports_dict
+def pad_center_to(
+    data: TensorTypeVar,
+    shape: Sequence[int],
+    mode: Literal["constant", "reflect", "replicate", "circular"] = "constant",
+    value: float | None = None,
+) -> TensorTypeVar:
+    """
+    Pad data to the given shape.
+    :param data: Input tensor
+    :param shape: Shape to pad input to. Must be bigger than data.shape.
+    :param mode: torch.nn.functional.pad's padding kwarg.
+    :param value: torch.nn.functional.pad's value kwarg.
+    :return: Padded tensor
+    """
+    ndim = len(shape)
+    pad = []
+    for insz, outsz in zip(data.shape[-ndim:], shape):
+        if isinstance(insz, torch.Tensor):  # pragma: no cover # only occurs for JIT
+            insz = insz.item()
+        assert outsz >= insz
+        lpad = (outsz - insz) // 2
+        rpad = (outsz - insz) - lpad
+        pad.extend([lpad, rpad])
+
+    # TODO: maybe use numpy instead - torch supports only float data currently
+    data_torch = tensor_ops.convert.to_torch(data)
+    result = torch.nn.functional.pad(data_torch, tuple(reversed(pad)), mode=mode, value=value)
+    return tensor_ops.convert.astype(result, data)


### PR DESCRIPTION
Pad a tensor to specified shape. This is a prereq for something else in `internal`