### PR TITLE
Fix ConstantVolumetricBackend / Feat VolumetricIndexTranslator 

### DIFF
--- a/zetta_utils/layer/volumetric/constant/backend.py
+++ b/zetta_utils/layer/volumetric/constant/backend.py
@@ -87,7 +87,8 @@ class ConstantVolumetricBackend(VolumetricBackend):  # pylint: disable=too-few-p
                     slices[0].stop - slices[0].start,
                     slices[1].stop - slices[1].start,
                     slices[2].stop - slices[2].start,
-                )
+                ),
+                dtype=self.dtype,
             )
             * self.value
         )

--- a/zetta_utils/layer/volumetric/tools.py
+++ b/zetta_utils/layer/volumetric/tools.py
@@ -19,12 +19,16 @@ logger = log.get_logger("zetta_utils")
 
 @typechecked
 def translate_volumetric_index(
-    idx: VolumetricIndex, offset: Sequence[float], resolution: Sequence[float]
+    idx: VolumetricIndex,
+    offset: Sequence[float],
+    resolution: Sequence[float],
+    allow_slice_rounding: bool,
 ):  # pragma: no cover # under 3 statements, no conditionals
     bbox = idx.bbox.translated(offset, resolution)
     result = VolumetricIndex(
         bbox=bbox,
         resolution=Vec3D(*idx.resolution),
+        allow_slice_rounding=allow_slice_rounding,
     )
     return result
 
@@ -35,12 +39,14 @@ def translate_volumetric_index(
 class VolumetricIndexTranslator:  # pragma: no cover # under 3 statements, no conditionals
     offset: Sequence[float]
     resolution: Sequence[float]
+    allow_slice_rounding: bool = False
 
     def __call__(self, idx: VolumetricIndex) -> VolumetricIndex:
         result = translate_volumetric_index(
             idx=idx,
             offset=self.offset,
             resolution=self.resolution,
+            allow_slice_rounding=self.allow_slice_rounding,
         )
         return result
 


### PR DESCRIPTION
* `ConstantVolumetricBackend` would return a volume of `np.float64`, yet the `dtype` getter is fixed to `np.float32`
* `VolumetricIndexTranslator` now optionally supports slice rounding - default is `False`, which matches the old behavior