### PR TITLE
feat(tools): VolumetricIndexScaler

### DIFF
--- a/tests/unit/layer/volumetric/test_tools.py
+++ b/tests/unit/layer/volumetric/test_tools.py
@@ -7,6 +7,7 @@ from zetta_utils.layer.volumetric import (
     VolumetricIndex,
     VolumetricIndexChunker,
     VolumetricIndexOverrider,
+    VolumetricIndexScaler,
 )
 from zetta_utils.layer.volumetric.tools import ROIMaskProcessor
 
@@ -117,6 +118,36 @@ def test_volumetric_index_overrider(
     assert index.start == Vec3D(*expected_start)
     assert index.stop == Vec3D(*expected_stop)
     assert index.resolution == Vec3D(*expected_resolution)
+
+
+@pytest.mark.parametrize(
+    """res_change_mult,
+    expected_start, expected_stop, expected_resolution""",
+    [
+        [[2, 2, 1], [2, 3, 6], [7, 7, 16], [2, 2, 1]],
+        [[1, 2, 3], [4, 3, 2], [14, 7, 5], [1, 2, 3]],
+    ],
+)
+def test_volumetric_index_scaler(
+    res_change_mult,
+    expected_start,
+    expected_stop,
+    expected_resolution,
+):
+    index = VolumetricIndex(resolution=Vec3D(1, 1, 1), bbox=BBox3D(((4, 14), (6, 14), (6, 16))))
+    vis = VolumetricIndexScaler(res_change_mult=res_change_mult, allow_slice_rounding=True)
+    index = vis(index)
+    assert index.start == Vec3D(*expected_start)
+    assert index.stop == Vec3D(*expected_stop)
+    assert index.resolution == Vec3D(*expected_resolution)
+
+
+def test_volumetric_index_scaler_error():
+    index = VolumetricIndex(resolution=Vec3D(1, 1, 1), bbox=BBox3D(((4, 14), (6, 14), (6, 16))))
+    vis = VolumetricIndexScaler(res_change_mult=[1, 2, 3])
+    index = vis(index)
+    with pytest.raises(ValueError):
+        index.stop
 
 
 @pytest.mark.parametrize(

--- a/zetta_utils/layer/volumetric/__init__.py
+++ b/zetta_utils/layer/volumetric/__init__.py
@@ -21,6 +21,7 @@ from .tools import (
     VolumetricIndexTranslator,
     VolumetricIndexChunker,
     VolumetricIndexOverrider,
+    VolumetricIndexScaler
 )
 from .layer import (
     VolumetricLayer,

--- a/zetta_utils/layer/volumetric/tools.py
+++ b/zetta_utils/layer/volumetric/tools.py
@@ -51,6 +51,22 @@ class VolumetricIndexTranslator:  # pragma: no cover # under 3 statements, no co
         return result
 
 
+@builder.register("VolumetricIndexScaler")
+@typechecked
+@attrs.mutable
+class VolumetricIndexScaler:  # pragma: no cover # under 3 statements, no conditionals
+    res_change_mult: Sequence[int]
+    allow_slice_rounding: bool = False
+
+    def __call__(self, idx: VolumetricIndex) -> VolumetricIndex:
+        result = VolumetricIndex(
+            bbox=idx.bbox,
+            resolution=idx.resolution * Vec3D(*self.res_change_mult),
+            allow_slice_rounding=self.allow_slice_rounding,
+        )
+        return result
+
+
 @builder.register("VolumetricIndexOverrider")
 @typechecked
 @attrs.mutable


### PR DESCRIPTION
Needed that for a `VolumetricCallableOperation` with `res_change_mult` and output mask. I want to read the output mask at the output resolution, rather than the input resolution used for the EM data.