### PR TITLE
fix(cloudvol/backend): Use default (auto) compression mode

### DIFF
--- a/zetta_utils/layer/volumetric/cloudvol/backend.py
+++ b/zetta_utils/layer/volumetric/cloudvol/backend.py
@@ -118,7 +118,7 @@ class CVBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
         self.cv_kwargs.setdefault("non_aligned_writes", False)
         self.cv_kwargs.setdefault("cache", False)
         self.cv_kwargs.setdefault("compress_cache", False)
-        self.cv_kwargs.setdefault("compress", True)
+        self.cv_kwargs.setdefault("compress", None)
         self.cv_kwargs.setdefault("cdn_cache", False)
         self.cv_kwargs.setdefault("fill_missing", True)
         self.cv_kwargs.setdefault("delete_black_uploads", True)


### PR DESCRIPTION
If not specified, CloudVolume will [pick a resonable compression mode based on the data encoding](https://github.com/seung-lab/cloud-volume/blob/355c85ba6b3c795a94eaf6e418e99cfeecf365c1/cloudvolume/datasource/precomputed/common.py#L12-L19).

Attempting to gzip JPG or PNG images is inefficient, but more importantly, it also seems to confuse CloudVolume and/or GCS when reading back the data: I keep getting checksum errors when trying to read these double-compressed images.