### PR TITLE
Disable CDN cache for volatile JSON objects

### DIFF
--- a/zetta_utils/layer/volumetric/precomputed/precomputed.py
+++ b/zetta_utils/layer/volumetric/precomputed/precomputed.py
@@ -46,7 +46,7 @@ def _write_info(
     info: Dict[str, Any], path: str
 ) -> None:  # pylint: disable=too-many-branches, consider-iterating-dictionary
     info_path = _to_info_path(path)
-    CloudFile(info_path).put_json(info)
+    CloudFile(info_path).put_json(info, cache_control="no-cache")
 
 
 def _to_info_path(path: str) -> str:

--- a/zetta_utils/parsing/ngl_state.py
+++ b/zetta_utils/parsing/ngl_state.py
@@ -115,4 +115,6 @@ def write_remote_annotations(
 
     cf = CloudFiles(remote_path)
     logger.info(f"Writing {len(bboxes_or_points)} bboxes/points to {remote_path}/{layer_name}.")
-    cf.put_json(layer_name, make_layer(layer_d).to_json())
+    cf.put_json(
+        layer_name, make_layer(layer_d).to_json(), compress="gzip", cache_control="no-cache"
+    )


### PR DESCRIPTION
I tend to modify info files more frequently during development and it always caused trouble. CloudVolume's `commit_info` hardcoded this as well to `no-cache`.

Also found a similar `put_json` call for the remote annotations, which I reckon act very much the same.