### PR TITLE
Update slurm execution code

### DIFF
--- a/specs/sergiy/slurm/copy_data.cue
+++ b/specs/sergiy/slurm/copy_data.cue
@@ -1,3 +1,5 @@
+import "list"
+
 #SRC_PATH: "tigerdata://sseung-test1/ca3-alignment-temp/full_section_imap4"
 #DST_PATH: "tigerdata://sseung-test1/sergiy-temp/tmp_x0"
 
@@ -9,13 +11,14 @@
 }
 
 "@type":                "mazepa.execute_on_slurm"
-worker_replicas: 10
+worker_replicas: 1
 worker_resources: {
 	cpus_per_task: 4,
 	mem_per_cpu: "8G"
 	// sres: ...
+	array: list.Range(0,4)
 }
-init_command:  "module load  anacondapy/2023.03; conda activate zetta-x1-p310"
+init_command:  "module load  anacondapy/2024.02; conda activate zetta-x1-p310"
 local_test:    false // set to `false` execute remotely
 message_queue: "sqs"
 

--- a/zetta_utils/mazepa_addons/configurations/execute_on_slurm.py
+++ b/zetta_utils/mazepa_addons/configurations/execute_on_slurm.py
@@ -189,7 +189,7 @@ def get_slurm_contex_managers(
     pathlib.Path(f"slurm_{execution_id}").mkdir()
     slurm_obj = Slurm(
         output=f"slurm_{execution_id}/{Slurm.JOB_ARRAY_ID}.out",
-        time=datetime.timedelta(days=0, hours=0, minutes=10, seconds=4),
+        time=datetime.timedelta(days=2, hours=0, minutes=0, seconds=0),
         ntasks=worker_replicas,
         partition="highpri",
         job_name=f"slurm-worker-{execution_id}",


### PR DESCRIPTION
Cleaned up the changes for Hippocampus - still not very configurable, but this is pretty much how I got the jobs to run in parallel with the correct GPUs assigned

At some point, I also had this hack below in `zetta_utils/__init__.py`, but I hope that's not needed anymore. I should have kept better track of all the (un)necessary changes to make things work, but we'll find out soon enough.

```python
    import os
    import torch
    gpu_id = os.environ.get('CUDA_VISIBLE_DEVICES', '0')  # Default to 0 if not set
    print(f"Setting CUDA_VISIBLE_DEVICES to {gpu_id}")
    torch.cuda.set_device(int(gpu_id))  # Set device to first allocated GPU
```
