### PR TITLE
fix: running jit models

### DIFF
--- a/zetta_utils/convnet/utils.py
+++ b/zetta_utils/convnet/utils.py
@@ -136,6 +136,8 @@ def load_and_run_model(
         output = tensor_ops.convert.astype(output_np, reference=data_in)
     else:
         autocast_device = device.type if isinstance(device, torch.device) else str(device)
-        with torch.autocast(device_type=autocast_device):
-            output = model(tensor_ops.convert.to_torch(data_in, device=device))
+        with torch.inference_mode():  # uses less memory when used with JITs
+            with torch.autocast(device_type=autocast_device):
+                output = model(tensor_ops.convert.to_torch(data_in, device=device))
+                output = tensor_ops.convert.astype(output, reference=data_in)
     return output


### PR DESCRIPTION
Notes:
- `with torch.inference_mode()` uses less memory. Without it I'd run out of mem. Not sure if it's applicable only for JITs or also other checkpoint types.
- `output = tensor_ops.convert.astype(output, reference=data_in)` was necessary anyway for `TensorTypeVar`, but without it the returned tensor is not detached and moved to CPU.