### PR TITLE
Change specs submodule from http:// to git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git@github.com:ZettaAI/internal.git
 [submodule "specs"]
 	path = specs
-	url = https://github.com/ZettaAI/specs
+	url = git@github.com:ZettaAI/specs.git


### PR DESCRIPTION
To be consistent with `internal` and to make my life easier when cloning (http:// doesn't use key and github disabled password based authentication a long time ago).