### PR TITLE
fix/typing(layer_set): Allow layer set read_proc to return single layer

### DIFF
--- a/zetta_utils/layer/volumetric/layer_set/layer.py
+++ b/zetta_utils/layer/volumetric/layer_set/layer.py
@@ -5,7 +5,6 @@ from typing import Mapping, Union
 import attrs
 import torch
 from numpy import typing as npt
-from typeguard import typechecked
 
 from ... import DataProcessor, IndexProcessor, JointIndexDataProcessor, Layer
 from .. import UserVolumetricIndex, VolumetricFrontend, VolumetricIndex
@@ -21,7 +20,6 @@ VolumetricSetDataWriteProcT = Union[
 ]
 
 
-@typechecked
 @attrs.frozen
 class VolumetricLayerSet(
     Layer[VolumetricIndex, dict[str, npt.NDArray], Mapping[str, npt.NDArray | torch.Tensor]]


### PR DESCRIPTION
Allows combining two layers with a read_proc, e.g. https://github.com/ZettaAI/specs/blob/main/nico/inference/chen_s1/11_fine_align_pairwise.cue#L196-L223

Already worked before, just the static type checker would complain.