### PR TITLE
fix(progress_tracker): Support for all debuggers with .set_trace()

### DIFF
--- a/zetta_utils/mazepa/progress_tracker.py
+++ b/zetta_utils/mazepa/progress_tracker.py
@@ -67,7 +67,7 @@ def progress_ctx_mngr(
         if val == "0":
             return None
         # else if the value is an empty string, invoke the default pdb debugger
-        elif val is not None and val != "pdb.set_trace":
+        elif val is not None and not val.endswith(".set_trace"):
             raise Exception(  # pylint: disable=broad-exception-raised
                 "Custom debuggers are not allowed when `rich.progress is in use.`"
             )


### PR DESCRIPTION
Avoids the exception caused by the new pdbp, which uses `pdbp.set_trace`