### PR TITLE
feat: mazepa hooks for AnnotationLayer setup and post-process; build_annotation_layer builder

### DIFF
--- a/tests/unit/db_annotations/test_precomp_annotations.py
+++ b/tests/unit/db_annotations/test_precomp_annotations.py
@@ -4,7 +4,10 @@ import shutil
 import pytest
 
 from zetta_utils.db_annotations import precomp_annotations
-from zetta_utils.db_annotations.precomp_annotations import LineAnnotation, SpatialFile
+from zetta_utils.db_annotations.precomp_annotations import (
+    AnnotationLayer,
+    LineAnnotation,
+)
 from zetta_utils.geometry.vec import Vec3D
 from zetta_utils.layer.volumetric.index import VolumetricIndex
 
@@ -26,19 +29,19 @@ def test_round_trip():
 
     index = VolumetricIndex.from_coords([0, 0, 0], [2000, 2000, 600], Vec3D(10, 10, 40))
 
-    sf = SpatialFile(file_dir, index)
+    sf = AnnotationLayer(file_dir, index)
     assert sf.chunk_sizes == [(2000, 2000, 600)]
 
     chunk_sizes = [[2000, 2000, 600], [1000, 1000, 600], [500, 500, 300]]
-    sf = SpatialFile(file_dir, index, chunk_sizes)
+    sf = AnnotationLayer(file_dir, index, chunk_sizes)
     os.makedirs(os.path.join(file_dir, "spatial0", "junkforcodecoverage"))
     sf.clear()
     sf.write_annotations([])  # (does nothing)
     sf.write_annotations(lines)
     sf.post_process()
 
-    # Now create a *new* SpatialFile, given just the directory.
-    sf = SpatialFile(file_dir)
+    # Now create a *new* AnnotationLayer, given just the directory.
+    sf = AnnotationLayer(file_dir)
     assert sf.index == index
     assert sf.chunk_sizes == chunk_sizes
 
@@ -67,7 +70,13 @@ def test_edge_cases():
     # pylint: disable=use-implicit-booleaness-not-comparison
     assert precomp_annotations.read_lines("/dev/null") == []
 
+    assert precomp_annotations.read_info("/dev/null") == (None, None, None, None)
+
     assert precomp_annotations.path_join("gs://foo/", "bar") == "gs://foo/bar"
+
+    index = VolumetricIndex.from_coords((0, 0, 0), (10, 10, 10), (1, 1, 1))
+    assert not AnnotationLayer("/dev/null", index).exists()
+    assert not AnnotationLayer("/dev/null/subdir", index).exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These changes enable the synapse detection and assignment pipeline to be run entirely from a CUE file, in principle making it usable from Zetta Portal.

(This is a high priority for @macrintr.)