### PR TITLE
HTTP/2 + Streaming Response

### DIFF
--- a/web_api/Dockerfile
+++ b/web_api/Dockerfile
@@ -10,4 +10,5 @@ RUN pip install --no-cache-dir -r requirements.txt && pip install '.[modules]'
 COPY . /opt/http
 RUN zetta --help
 
-CMD ["uvicorn", "app.main:app", "--app-dir", "./web_api" "--host", "0.0.0.0", "--port", "80"]
+WORKDIR /opt/http/web_api
+CMD ["hypercorn", "app.main:app", "--bind", "0.0.0.0:80"]

--- a/web_api/requirements.txt
+++ b/web_api/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 pydantic
-uvicorn
+hypercorn
 google-cloud-iap


### PR DESCRIPTION
Based on the comments in https://cloud.google.com/run/quotas#request_limits
* Remove 32 MiB request size limit by switching from uvicorn to hypercorn with HTTP/2 support
* Remove 32 MIB response size limit by using FastAPI Streaming response (which sets `Transfer-Encoding: chunked`)