### PR TITLE
Precomputed_annotations web API (#797).

### DIFF
--- a/tests/unit/db_annotations/test_annotation.py
+++ b/tests/unit/db_annotations/test_annotation.py
@@ -59,9 +59,12 @@ def test_add_update_delete_annotation(
     )
 
     _annotation = annotation.read_annotation(_id)
-    assert _annotation.collection_id == collection_id
-    assert _annotation.layer_group_id == layer_group_id
+    assert _annotation.collection == collection_id
+    assert _annotation.layer_group == layer_group_id
     assert len(cast(list, _annotation.tags)) == 2
+
+    _annotation_d = _annotation.to_dict()
+    assert _annotation_d["collection"] == _annotation.collection
 
     annotation.update_annotation(
         _id,

--- a/tests/unit/db_annotations/test_precomp_annotations.py
+++ b/tests/unit/db_annotations/test_precomp_annotations.py
@@ -50,6 +50,12 @@ def test_round_trip():
     for line in lines:
         assert line in lines_read
 
+    idx = VolumetricIndex.from_coords((1000, 500, 300), (1500, 1000, 1000), Vec3D(10, 10, 40))
+    lines_read = sf.read_in_bounds(idx)
+    assert len(lines_read) == 2
+    for line in lines[-2:]:
+        assert line in lines_read
+
     # Above is typical usage.  Below, we do some odd things
     # to trigger other code paths we want to test.
     lines_read = sf.read_all(-1, False)  # allow duplicates

--- a/web_api/app/annotations.py
+++ b/web_api/app/annotations.py
@@ -27,7 +27,7 @@ async def generic_handler(request: Request, exc: Exception):
 
 @api.get("/single/{annotation_id}")
 async def read_single(annotation_id: str):
-    return read_annotation(annotation_id)
+    return read_annotation(annotation_id).dict()
 
 
 @api.post("/single")
@@ -84,7 +84,7 @@ async def read_multiple(
     response = []
     for _id, annotation in annotations.items():
         annotation.id = _id
-        response.append(annotation)
+        response.append(annotation.dict())
     return response
 
 

--- a/web_api/app/annotations.py
+++ b/web_api/app/annotations.py
@@ -27,7 +27,7 @@ async def generic_handler(request: Request, exc: Exception):
 
 @api.get("/single/{annotation_id}")
 async def read_single(annotation_id: str):
-    return read_annotation(annotation_id).dict()
+    return read_annotation(annotation_id).to_dict()
 
 
 @api.post("/single")
@@ -84,7 +84,7 @@ async def read_multiple(
     response = []
     for _id, annotation in annotations.items():
         annotation.id = _id
-        response.append(annotation.dict())
+        response.append(annotation.to_dict())
     return response
 
 

--- a/web_api/app/collections.py
+++ b/web_api/app/collections.py
@@ -1,6 +1,7 @@
 # pylint: disable=all # type: ignore
 from typing import Annotated
 
+from attrs import asdict
 from fastapi import FastAPI, HTTPException, Query, Request
 
 from zetta_utils.db_annotations.annotation import delete_annotations, read_annotations
@@ -29,7 +30,7 @@ async def generic_handler(request: Request, exc: Exception):
 
 @api.get("/single/{collection_id}")
 async def read_single(collection_id: str):
-    return read_collection(collection_id)
+    return asdict(read_collection(collection_id))
 
 
 @api.post("/single")
@@ -62,7 +63,7 @@ async def read_multiple(collection_ids: Annotated[list[str] | None, Query()] = N
     response = []
     for _id, collection in collections.items():
         collection.id = _id
-        response.append(collection)
+        response.append(asdict(collection))
     return response
 
 

--- a/web_api/app/layer_groups.py
+++ b/web_api/app/layer_groups.py
@@ -1,6 +1,7 @@
 # pylint: disable=all # type: ignore
 from typing import Annotated
 
+from attrs import asdict
 from fastapi import FastAPI, HTTPException, Query, Request
 
 from zetta_utils.db_annotations.layer_group import (
@@ -24,7 +25,7 @@ async def generic_handler(request: Request, exc: Exception):
 
 @api.get("/single/{layer_group_id}")
 async def read_single(layer_group_id: str):
-    return read_layer_group(layer_group_id)
+    return asdict(read_layer_group(layer_group_id))
 
 
 @api.post("/single")
@@ -75,7 +76,7 @@ async def read_multiple(
     collection_ids: Annotated[list[str] | None, Query()] = None,
 ):
     if layer_group_ids:
-        return read_layer_groups(layer_group_ids=layer_group_ids)
+        return [asdict(x) for x in read_layer_groups(layer_group_ids=layer_group_ids)]
     if collection_ids:
         layer_groups = read_layer_groups(collection_ids=collection_ids)
     else:
@@ -83,7 +84,7 @@ async def read_multiple(
     response = []
     for _id, layer_group in layer_groups.items():
         layer_group.id = _id
-        response.append(layer_group)
+        response.append(asdict(layer_group))
     return response
 
 

--- a/web_api/app/layers.py
+++ b/web_api/app/layers.py
@@ -1,6 +1,7 @@
 # pylint: disable=all # type: ignore
 from typing import Annotated
 
+from attrs import asdict
 from fastapi import FastAPI, Query, Request
 
 from zetta_utils.db_annotations.layer import (
@@ -22,7 +23,7 @@ async def generic_handler(request: Request, exc: Exception):
 
 @api.get("/single/{layer_id}")
 async def read_single(layer_id: str):
-    return read_layer(layer_id)
+    return asdict(read_layer(layer_id))
 
 
 @api.post("/single")
@@ -40,10 +41,10 @@ async def update_single(
 @api.get("/multiple")
 async def read_multiple(layer_ids: Annotated[list[str] | None, Query()] = None):
     if layer_ids:
-        return read_layers(layer_ids=layer_ids)
+        return [asdict(x) for x in read_layers(layer_ids=layer_ids)]
     layers = read_layers()
     response = []
     for _id, layer in layers.items():
         layer.id = _id
-        response.append(layer)
+        response.append(asdict(layer))
     return response

--- a/web_api/app/main.py
+++ b/web_api/app/main.py
@@ -32,7 +32,7 @@ app.mount("/collections", collections_api)
 app.mount("/layer_groups", layer_groups_api)
 app.mount("/layers", layers_api)
 app.mount("/painting", painting_api)
-app.mount("/precomputed_annotations", precomputed_annotations_api)
+app.mount("/precomputed", precomputed_annotations_api)
 
 
 @app.middleware("http")

--- a/web_api/app/main.py
+++ b/web_api/app/main.py
@@ -15,6 +15,7 @@ from .collections import api as collections_api
 from .layer_groups import api as layer_groups_api
 from .layers import api as layers_api
 from .painting import api as painting_api
+from .precomputed_annotations import api as precomputed_annotations_api
 
 app = FastAPI()
 
@@ -31,6 +32,7 @@ app.mount("/collections", collections_api)
 app.mount("/layer_groups", layer_groups_api)
 app.mount("/layers", layers_api)
 app.mount("/painting", painting_api)
+app.mount("/precomputed_annotations", precomputed_annotations_api)
 
 
 @app.middleware("http")

--- a/web_api/app/precomputed_annotations.py
+++ b/web_api/app/precomputed_annotations.py
@@ -3,6 +3,7 @@ This file provides web API endpoints for manipulating annotations stored in
 precomputed (i.e. Neuroglancer) file format.  Design reference:
 https://github.com/ZettaAI/zetta_utils/issues/797
 """
+
 from typing import Annotated
 
 # pylint: disable=all # type: ignore
@@ -45,13 +46,13 @@ async def read_in_bounds(
     for line in layer.read_in_bounds(index):
         annotation = AnnotationDBEntry(
             id=line.id,
-            layer_group_id="",
-            collection_id="",
+            layer_group="",
+            collection="",
             comment="",
             tags=[],
             ng_annotation=LineAnnotation(pointA=line.start, pointB=line.end),
         )
-        response.append(annotation.dict())
+        response.append(annotation.to_dict())
     return response
 
 

--- a/web_api/app/precomputed_annotations.py
+++ b/web_api/app/precomputed_annotations.py
@@ -30,7 +30,7 @@ async def generic_handler(request: Request, exc: Exception):
     return generic_exception_handler(request, exc)
 
 
-@api.get("/")
+@api.get("/annotations")
 async def read_in_bounds(
     path: Annotated[str, Query()],
     bbox_start: Annotated[tuple[int, int, int], Query()],
@@ -56,7 +56,7 @@ async def read_in_bounds(
     return response
 
 
-@api.put("/")
+@api.put("/annotations")
 async def add_multiple(
     annotations: list[dict],
     path: Annotated[str, Query()],
@@ -80,7 +80,7 @@ async def add_multiple(
     layer.write_annotations(lines)
 
 
-@api.delete("/")
+@api.delete("/annotations")
 async def delete_multiple(
     path: Annotated[str, Query()],
 ):

--- a/web_api/app/precomputed_annotations.py
+++ b/web_api/app/precomputed_annotations.py
@@ -1,0 +1,91 @@
+"""
+This file provides web API endpoints for manipulating annotations stored in
+precomputed (i.e. Neuroglancer) file format.  Design reference:
+https://github.com/ZettaAI/zetta_utils/issues/797
+"""
+from typing import Annotated
+
+# pylint: disable=all # type: ignore
+from attrs import asdict
+from fastapi import FastAPI, Query, Request
+from neuroglancer.viewer_state import LineAnnotation
+
+from zetta_utils.db_annotations import precomp_annotations
+from zetta_utils.db_annotations.annotation import AnnotationDBEntry, NgAnnotation
+from zetta_utils.db_annotations.precomp_annotations import (
+    AnnotationLayer,
+    build_annotation_layer,
+)
+from zetta_utils.geometry import Vec3D
+from zetta_utils.layer.volumetric import VolumetricIndex
+
+from .utils import generic_exception_handler
+
+api = FastAPI()
+
+
+@api.exception_handler(Exception)
+async def generic_handler(request: Request, exc: Exception):
+    return generic_exception_handler(request, exc)
+
+
+@api.get("/")
+async def read_in_bounds(
+    path: Annotated[str, Query()],
+    bbox_start: Annotated[tuple[int, int, int], Query()],
+    bbox_end: Annotated[tuple[int, int, int], Query()],
+    resolution: Annotated[tuple[float, float, float], Query()],
+):
+    """
+    This endpoint retrieves all lines within the given bounds.
+    """
+    index = VolumetricIndex.from_coords(bbox_start, bbox_end, Vec3D(*resolution))
+    layer = build_annotation_layer(path, mode="read")
+    response = []
+    for line in layer.read_in_bounds(index):
+        annotation = AnnotationDBEntry(
+            id=line.id,
+            layer_group_id="",
+            collection_id="",
+            comment="",
+            tags=[],
+            ng_annotation=LineAnnotation(pointA=line.start, pointB=line.end),
+        )
+        response.append(annotation.dict())
+    return response
+
+
+@api.put("/")
+async def add_multiple(
+    annotations: list[dict],
+    path: Annotated[str, Query()],
+    bbox_start: Annotated[tuple[int, int, int], Query()],
+    bbox_end: Annotated[tuple[int, int, int], Query()],
+    resolution: Annotated[tuple[float, float, float], Query()],
+):
+    """
+    The PUT endpoint replaces all data in the given file (which may or
+    may not exist yet) with the given new set of lines.
+    """
+    lines = []
+    for entry in annotations:
+        annotation = AnnotationDBEntry.from_dict(entry["id"], entry)
+        line = annotation.ng_annotation
+        lines.append(
+            precomp_annotations.LineAnnotation(int(annotation.id), line.point_a, line.point_b)
+        )
+    index = VolumetricIndex.from_coords(bbox_start, bbox_end, Vec3D(*resolution))
+    layer = build_annotation_layer(path, index=index, mode="replace")
+    layer.write_annotations(lines)
+
+
+@api.delete("/")
+async def delete_multiple(
+    path: Annotated[str, Query()],
+):
+    """
+    The DELETE endpoint deletes the specified precomputed annotation
+    file.  Use with caution.
+    """
+    layer = build_annotation_layer(path, mode="write")
+    layer.delete()

--- a/zetta_utils/db_annotations/annotation.py
+++ b/zetta_utils/db_annotations/annotation.py
@@ -47,8 +47,8 @@ ANNOTATIONS_DB = build_firestore_layer(
 @attrs.mutable
 class AnnotationDBEntry:
     id: str
-    layer_group_id: str
-    collection_id: str
+    layer_group: str
+    collection: str
     ng_annotation: NgAnnotation
     comment: str
     tags: list[str]
@@ -65,24 +65,18 @@ class AnnotationDBEntry:
 
         result = AnnotationDBEntry(
             id=annotation_id,
-            layer_group_id=raw_with_defaults["layer_group"],
-            collection_id=raw_with_defaults["collection"],
+            layer_group=raw_with_defaults["layer_group"],
+            collection=raw_with_defaults["collection"],
             comment=raw_with_defaults["comment"],
             tags=raw_with_defaults["tags"],
             ng_annotation=ng_annotation,
         )
         return result
 
-    def dict(self) -> dict[str, Any]:
-        result = self.ng_annotation.to_json()
-        if self.layer_group_id:
-            result["layer_group"] = self.layer_group_id
-        if self.collection_id:
-            result["collection"] = self.collection_id
-        if self.comment:
-            result["comment"] = self.comment
-        if self.tags:
-            result["tags"] = self.tags
+    def to_dict(self):
+        result = dict(self.ng_annotation.to_json())
+        result.update(attrs.asdict(self))
+        del result["ng_annotation"]
         return result
 
 

--- a/zetta_utils/db_annotations/annotation.py
+++ b/zetta_utils/db_annotations/annotation.py
@@ -73,6 +73,18 @@ class AnnotationDBEntry:
         )
         return result
 
+    def dict(self) -> dict[str, Any]:
+        result = self.ng_annotation.to_json()
+        if self.layer_group_id:
+            result["layer_group"] = self.layer_group_id
+        if self.collection_id:
+            result["collection"] = self.collection_id
+        if self.comment:
+            result["comment"] = self.comment
+        if self.tags:
+            result["tags"] = self.tags
+        return result
+
 
 def read_annotation(annotation_id: str) -> AnnotationDBEntry:
     idx = (annotation_id, INDEXED_COLS + NON_INDEXED_COLS)

--- a/zetta_utils/db_annotations/collection.py
+++ b/zetta_utils/db_annotations/collection.py
@@ -29,8 +29,9 @@ class CollectionDBEntry:
     name: str
     created_by: str
     created_at: float
-    modified_by: str
-    modified_at: float
+    modified_by: str | None
+    modified_at: float | None
+    comment: str | None
 
     @staticmethod
     def from_dict(collection_id: str, raw_dict: Mapping) -> CollectionDBEntry:
@@ -39,8 +40,9 @@ class CollectionDBEntry:
             name=raw_dict["name"],
             created_by=raw_dict["created_by"],
             created_at=raw_dict["created_at"],
-            modified_by=raw_dict["modified_by"],
-            modified_at=raw_dict["modified_at"],
+            modified_by=raw_dict.get("modified_by"),
+            modified_at=raw_dict.get("modified_at"),
+            comment=raw_dict.get("comment"),
         )
 
 

--- a/zetta_utils/db_annotations/layer_group.py
+++ b/zetta_utils/db_annotations/layer_group.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Mapping, cast
+from typing import List, Mapping, cast, overload
 
 import attrs
 
@@ -26,9 +26,10 @@ LAYER_GROUPS_DB = build_firestore_layer(
 class LayerGroupDBEntry:
     id: str
     name: str
-    collection_id: str
+    collection: str
     layers: list[str]
     created_by: str
+    modified_by: str | None
 
     @staticmethod
     def from_dict(layer_group_id: str, raw_dict: Mapping) -> LayerGroupDBEntry:
@@ -36,7 +37,8 @@ class LayerGroupDBEntry:
             id=layer_group_id,
             name=raw_dict["name"],
             created_by=raw_dict["created_by"],
-            collection_id=raw_dict["collection"],
+            modified_by=raw_dict.get("modified_by"),
+            collection=raw_dict["collection"],
             layers=raw_dict["layers"],
         )
 
@@ -48,19 +50,14 @@ def read_layer_group(layer_group_id: str) -> LayerGroupDBEntry:
     return result
 
 
-# TODO: mypy bug fixed in 1.11
-# @overload
-# def read_layer_groups(  # type: ignore
-#     *, layer_group_ids: list[str] = ..., collection_ids: None = ...
-# ) -> list[LayerGroupDBEntry]:
-#     ...
+@overload
+def read_layer_groups(*, layer_group_ids: list[str]) -> list[LayerGroupDBEntry]:
+    ...
 
 
-# @overload
-# def read_layer_groups( # type: ignore
-#     *, layer_group_ids: None = ..., collection_ids: list[str] | None = ...
-# ) -> dict[str, LayerGroupDBEntry]:
-#     ...
+@overload
+def read_layer_groups(*, collection_ids: list[str] | None = None) -> dict[str, LayerGroupDBEntry]:
+    ...
 
 
 def read_layer_groups(*, layer_group_ids=None, collection_ids=None):

--- a/zetta_utils/layer/db_layer/datastore/backend.py
+++ b/zetta_utils/layer/db_layer/datastore/backend.py
@@ -198,7 +198,7 @@ class DatastoreBackend(DBBackend):
         If index provided, delete rows from the index.
         Else delete all rows.
         """
-        if idx:
+        if idx is not None:
             keys: list[Key] = []
             for _key, col_keys in self._get_row_col_keys(idx.row_keys, ds_keys=True).items():
                 keys.extend(col_keys)

--- a/zetta_utils/layer/db_layer/firestore/backend.py
+++ b/zetta_utils/layer/db_layer/firestore/backend.py
@@ -135,7 +135,7 @@ class FirestoreBackend(DBBackend):
         If index provided, delete rows from the index; else, delete all rows.
         """
         bulk_writer = self.client.bulk_writer()
-        if idx:
+        if idx is not None:
             doc_refs = [self.client.collection(self.collection).document(k) for k in idx.row_keys]
         else:
             collection_ref = self.client.collection(self.collection)


### PR DESCRIPTION
Implements #797.

For PUT and DELETE verbs, it turned out to be simplest to treat the file as a unit, i.e., PUT replaces the entire file and DELETE deletes the file.  (This also seems like a good fit for the resource model of REST APIs.)

Some changes also affect the `/annotations` endpoint, which @akhileshh found was broken in the current version.  It should be fixed with this PR.
