### PR TITLE
Joe/hotfix uint32 writes

### DIFF
--- a/tests/unit/db_annotations/test_precomp_annotations.py
+++ b/tests/unit/db_annotations/test_precomp_annotations.py
@@ -50,11 +50,19 @@ def test_round_trip():
     for line in lines:
         assert line in lines_read
 
-    idx = VolumetricIndex.from_coords((1000, 500, 300), (1500, 1000, 1000), Vec3D(10, 10, 40))
-    lines_read = sf.read_in_bounds(idx)
+    idx = VolumetricIndex.from_coords((255, 0, 300), (1500, 1000, 1000), Vec3D(10, 10, 40))
+    # With that index, and strict=False, we would get at least 3 lines (ids 3, 4, and 5).
+    lines_read = sf.read_in_bounds(idx, strict=False)
+    assert len(lines_read) == 3
+    for line in lines[-2:]:
+        assert line in lines_read
+        assert line.id in [3, 4, 5]
+    # But with strict=True, we should get only 2 lines (ids 4 and 5).
+    lines_read = sf.read_in_bounds(idx, strict=True)
     assert len(lines_read) == 2
     for line in lines[-2:]:
         assert line in lines_read
+        assert line.id in [4, 5]
 
     # Above is typical usage.  Below, we do some odd things
     # to trigger other code paths we want to test.

--- a/zetta_utils/db_annotations/precomp_annotations.py
+++ b/zetta_utils/db_annotations/precomp_annotations.py
@@ -555,9 +555,12 @@ class AnnotationLayer:
             result = list(result_dict.values())
         return result
 
-    def read_in_bounds(self, index: VolumetricIndex):
+    def read_in_bounds(self, index: VolumetricIndex, strict: bool = False):
         """
-        Return all annotations within the given bounds (index).
+        Return all annotations within the given bounds (index).  If strict is
+        true, return ONLY annotations entirely within the given bounds.  If it
+        is false, then you may also get some annotations that are partially or
+        entirely outside the given bounds.
         """
         level = len(self.chunk_sizes) - 1
         result = []
@@ -573,6 +576,10 @@ class AnnotationLayer:
                 for z in range(max(0, start_chunk[2]), min(grid_shape[2], end_chunk[2])):
                     anno_file_path = path_join(level_dir, f"{x}_{y}_{z}")
                     result += read_lines(anno_file_path)
+        if strict:
+            result = list(
+                filter(lambda x: index.contains(x.start) and index.contains(x.end), result)
+            )
         result_dict = {line.id: line for line in result}
         result = list(result_dict.values())
         return result

--- a/zetta_utils/tensor_ops/common.py
+++ b/zetta_utils/tensor_ops/common.py
@@ -477,7 +477,7 @@ def _interpolate_with_torch(
         result_raw = result_raw > mask_value_thr
 
     result_raw = result_raw.to(data_torch.dtype)
-    result = tensor_ops.convert.astype(result_raw, data)
+    result = tensor_ops.convert.astype(result_raw, data, cast=True)
     return result
 
 


### PR DESCRIPTION
Yesterday I found a bug where it was impossible to write to a CloudVolume of type `uint32` (at least when using interpolation type `segmentation`, because under the hood, even if you gave it data of that type, it would be converted to `int32` before writing.

This fixes that by casting back to the original data type after interpolation.
