### PR TITLE
Fix incorrect argument type to torch.maximum.

### DIFF
--- a/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py
@@ -95,7 +95,9 @@ class ReduceNaive(ReduceOperation):
                     intscn, subidx = src_idx.get_intersection_and_subindex(red_idx)
                     subidx_channels = [slice(0, res.shape[0])] + list(subidx)
                     with semaphore("read"):
-                        res[subidx_channels] = torch.maximum(res[subidx_channels], layer[intscn])
+                        res[subidx_channels] = torch.maximum(
+                            res[subidx_channels], convert.to_torch(layer[intscn], res.device)
+                        )
             else:
                 for src_idx, layer in zip(src_idxs, src_layers):
                     intscn, subidx = src_idx.get_intersection_and_subindex(red_idx)


### PR DESCRIPTION
As noted [on Slack](https://zettaai.slack.com/archives/C03TJ1FPJTD/p1728665060174609), I ran into a bug trying to use the "max" blend mode.

```
mazepa /home/joe/zetta_utils/zetta_utils/mazepa/execution_state.py: 138                                                                  
Task traceback: Traceback (most recent call last):                                                                                       
File "/opt/zetta_utils/zetta_utils/mazepa/tasks.py", line 99, in __call__                                                              
return_value = self._call_task_fn(debug=debug)                                                                                       
File "/opt/zetta_utils/zetta_utils/mazepa/tasks.py", line 79, in _call_task_fn                                                         
return_value = self.fn(*self.args, **self.kwargs)                                                                                    
File "/opt/zetta_utils/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py", line 98, in __call__                      
res[subidx_channels] = torch.maximum(res[subidx_channels], layer[intscn])                                                            
TypeError: maximum(): argument 'other' (position 2) must be Tensor, not numpy.ndarray 
```

This change appears to fix that, by using `convert.to_torch` to ensure the second argument is a Tensor.