### PR TITLE
Support for `np.nan` background_color

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pyyaml ~= 6.0.1",
   "requests==2.31.0", # version conflicts otherwise
   "requests-oauthlib==1.3.1", # version conflicts otherwise
-  "cloud-files == 4.20.1",
+  "cloud-files >= 4.24.0",
   "packaging >= 23.2",
   "pdbp >= 1.5.3",
   "boto3 == 1.28.4",
@@ -54,7 +54,7 @@ augmentations = [
 ]
 cli = ["click == 8.0.1"]
 cloudvol = [
-  "cloud-volume == 8.27.0",
+  "cloud-volume[all_codecs] ~= 11.0.2",  # support for NaN bg color
   "zetta_utils[tensor_ops]",
 ]
 tensorstore = [

--- a/zetta_utils/builder/__init__.py
+++ b/zetta_utils/builder/__init__.py
@@ -1,21 +1,26 @@
 """Building objects from specs"""
 import inspect
 from typing import List
+
 import numpy as np
-from . import constants
-from .registry import REGISTRY, register, get_matching_entry, unregister
+
+from . import built_in_registrations, constants
 from .building import (
     SPECIAL_KEYS,
-    build,
     BuilderPartial,
-    get_initial_builder_spec,
     UnpicklableDict,
+    build,
+    get_initial_builder_spec,
 )
-from . import built_in_registrations
+from .registry import REGISTRY, get_matching_entry, register, unregister
 
 PARALLEL_BUILD_ALLOWED: bool = False
 
 NP_MANUAL: List[str] = []
 for k in dir(np):
-    if not k.startswith("_") and k not in NP_MANUAL and inspect.isroutine(getattr(np, k)):
-        register(f"np.{k}")(getattr(np, k))
+    if not k.startswith("_") and k not in NP_MANUAL:
+        if inspect.isroutine(getattr(np, k)):
+            register(f"np.{k}")(getattr(np, k))
+        elif isinstance(getattr(np, k), (float, type(None))):
+            # Add inf, nan, newaxis (None), etc. to cue specs
+            register(f"np.{k}")(lambda k=k: getattr(np, k))


### PR DESCRIPTION
Updates CloudVolume (see https://github.com/seung-lab/cloud-volume/issues/641)

Allows cue specs with NaN support... kinda:
```json
{
	"@type": "build_cv_layer"
	"path":   "..."
	"cv_kwargs": {
		"background_color": { "@type": "np.nan"}
	}
}
```