### PR TITLE
fix(parsing/cue): require all regular fields to be concrete

### DIFF
--- a/zetta_utils/parsing/cue.py
+++ b/zetta_utils/parsing/cue.py
@@ -68,7 +68,7 @@ def load(path):
                 tmp_f.write(contents)
                 tmp_f.flush()
             # Do a quick check for valid CUE before proceeding any further
-            result = subprocess.run(["cue", "vet", local_tmp_path], check=True)
+            result = subprocess.run(["cue", "vet", "-c", local_tmp_path], check=True)
             # Then, return file contents
             result = load_local(local_tmp_path)
     return result


### PR DESCRIPTION
Immediately shows incomplete fields, rather than `some instances are incomplete; use the -c flag to show errors or suppress this message` (see [documentation](https://cuelang.org/docs/reference/command/cue-help-vet/))