### PR TITLE
fix(cloudvol/write): allow sharded writes by removing forced autocrop

### DIFF
--- a/zetta_utils/layer/volumetric/cloudvol/backend.py
+++ b/zetta_utils/layer/volumetric/cloudvol/backend.py
@@ -222,15 +222,12 @@ class CVBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
 
         cvol = _get_cv_cached(self.path, idx.resolution, **self.cv_kwargs)
         slices = idx.to_slices()
-        # Enable autocrop for writes only
-        cvol.autocrop = True
 
         if (cvol.dtype == "uint64") and (data_final.dtype == np.int64):
             if data_final.min() < np.int64(0):
                 raise ValueError("Attempting to write negative values to a uint64 CloudVolume")
             data_final = data_final.astype(np.uint64)
         cvol[slices] = data_final
-        cvol.autocrop = False
 
     def with_changes(self, **kwargs) -> CVBackend:
         """Currently untyped. Supports:


### PR DESCRIPTION
@supersergiy This autocrop was added two years ago. Can you imagine why? Right now it prevents me from uploading shards at the dataset boundary, when the shard as a whole is not aligned with the dataset bounds.