### PR TITLE
fix(tensorstore): update tensorstore & builder import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ cloudvol = [
 ]
 tensorstore = [
   "boto3 == 1.28.4",
-  "tensorstore == 0.1.33",
+  "tensorstore == 0.1.71",
   "zetta_utils[tensor_ops]",
 ]
 convnet = ["torch >= 2.0", "artificery >= 0.0.3.3", "onnx2torch"]

--- a/zetta_utils/layer/volumetric/__init__.py
+++ b/zetta_utils/layer/volumetric/__init__.py
@@ -1,31 +1,37 @@
 import torch
 
 from zetta_utils.tensor_ops import convert
-
-from .backend import VolumetricBackend
-from .build import build_volumetric_layer
-from .constant import ConstantVolumetricBackend, build_constant_volumetric_layer
-from .frontend import (
-    SliceUserVolumetricIndex,
-    UnconvertedUserVolumetricIndex,
-    UserVolumetricIndex,
-    VolumetricFrontend,
+from .index import (
+    VolumetricIndex,
 )
-from .index import VolumetricIndex
-from .layer import VolumetricLayer
-from .layer_set import VolumetricLayerSet, build_volumetric_layer_set
-from .protocols import VolumetricBasedLayerProtocol
-from .tensorstore import build
+from .backend import VolumetricBackend
+from .frontend import (
+    VolumetricFrontend,
+    UserVolumetricIndex,
+    UnconvertedUserVolumetricIndex,
+    SliceUserVolumetricIndex,
+)
+
+
 from .tools import (
     DataResolutionInterpolator,
     InvertProcessor,
     ROIMaskProcessor,
+    VolumetricIndexPadder,
+    VolumetricIndexTranslator,
     VolumetricIndexChunker,
     VolumetricIndexOverrider,
-    VolumetricIndexPadder,
     VolumetricIndexScaler,
-    VolumetricIndexTranslator,
 )
+from .layer import (
+    VolumetricLayer,
+)
+from .build import build_volumetric_layer
+from .tensorstore import build
+
+from .constant import ConstantVolumetricBackend, build_constant_volumetric_layer
+from .layer_set import VolumetricLayerSet, build_volumetric_layer_set
+from .protocols import VolumetricBasedLayerProtocol
 
 VolumetricLayerDType = torch.Tensor
 to_vol_layer_dtype = convert.to_torch

--- a/zetta_utils/layer/volumetric/__init__.py
+++ b/zetta_utils/layer/volumetric/__init__.py
@@ -1,36 +1,31 @@
 import torch
 
 from zetta_utils.tensor_ops import convert
-from .index import (
-    VolumetricIndex,
-)
+
 from .backend import VolumetricBackend
+from .build import build_volumetric_layer
+from .constant import ConstantVolumetricBackend, build_constant_volumetric_layer
 from .frontend import (
-    VolumetricFrontend,
-    UserVolumetricIndex,
-    UnconvertedUserVolumetricIndex,
     SliceUserVolumetricIndex,
+    UnconvertedUserVolumetricIndex,
+    UserVolumetricIndex,
+    VolumetricFrontend,
 )
-
-
+from .index import VolumetricIndex
+from .layer import VolumetricLayer
+from .layer_set import VolumetricLayerSet, build_volumetric_layer_set
+from .protocols import VolumetricBasedLayerProtocol
+from .tensorstore import build
 from .tools import (
     DataResolutionInterpolator,
     InvertProcessor,
     ROIMaskProcessor,
-    VolumetricIndexPadder,
-    VolumetricIndexTranslator,
     VolumetricIndexChunker,
     VolumetricIndexOverrider,
+    VolumetricIndexPadder,
     VolumetricIndexScaler,
+    VolumetricIndexTranslator,
 )
-from .layer import (
-    VolumetricLayer,
-)
-from .build import build_volumetric_layer
-
-from .constant import ConstantVolumetricBackend, build_constant_volumetric_layer
-from .layer_set import VolumetricLayerSet, build_volumetric_layer_set
-from .protocols import VolumetricBasedLayerProtocol
 
 VolumetricLayerDType = torch.Tensor
 to_vol_layer_dtype = convert.to_torch

--- a/zetta_utils/layer/volumetric/tensorstore/build.py
+++ b/zetta_utils/layer/volumetric/tensorstore/build.py
@@ -14,6 +14,7 @@ from .. import VolumetricIndex, VolumetricLayer, build_volumetric_layer
 from ..precomputed import InfoExistsModes, PrecomputedInfoSpec
 from . import TSBackend
 
+
 # from typeguard import typechecked
 # @typechecked # ypeError: isinstance() arg 2 must be a type or tuple of types on p3.9
 @builder.register("build_ts_layer")

--- a/zetta_utils/layer/volumetric/tensorstore/build.py
+++ b/zetta_utils/layer/volumetric/tensorstore/build.py
@@ -15,7 +15,6 @@ from ..precomputed import InfoExistsModes, PrecomputedInfoSpec
 from . import TSBackend
 
 # from typeguard import typechecked
-
 # @typechecked # ypeError: isinstance() arg 2 must be a type or tuple of types on p3.9
 @builder.register("build_ts_layer")
 def build_ts_layer(  # pylint: disable=too-many-locals


### PR DESCRIPTION
ts=0.1.33 is incompatible with some setups with the below error

```
      WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
      Traceback (most recent call last):
        File "/tmp/pip-build-env-rqacn702/overlay/lib/python3.12/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject
          section = defn.get("tool", {})[tool_name]
                    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
      KeyError: 'setuptools_scm'
```