### PR TITLE
Joe/feat 806

### DIFF
--- a/scripts/precomp_lines_to_cave.py
+++ b/scripts/precomp_lines_to_cave.py
@@ -14,7 +14,7 @@ from sqlalchemy import text as sql
 from sqlalchemy.engine import URL
 
 from zetta_utils.db_annotations.precomp_annotations import build_annotation_layer
-from zetta_utils.geometry import Vec3D
+from zetta_utils.geometry import BBox3D, Vec3D
 from zetta_utils.layer.volumetric import VolumetricIndex
 
 # Database connection parameters
@@ -176,8 +176,8 @@ def load_annotations():
             bbox_start = input_vec3Di("  Bounds start")
             bbox_end = input_vec3Di("    Bounds end")
             resolution = input_vec3Di("    Resolution")
-            index = VolumetricIndex.from_coords(bbox_start, bbox_end, resolution)
-            lines = layer.read_in_bounds(index, strict=True)
+            bbox = BBox3D.from_coords(bbox_start, bbox_end, resolution)
+            lines = layer.read_in_bounds(bbox, strict=True)
         else:
             lines = layer.read_all()
         items = [


### PR DESCRIPTION
Adds `clearing_bbox` parameter to Annotation.write_in_bounds, and uses this in the PUT web API to replace only the annotations in the specified region.

Also shores up how resolution is handled — reading and writing now allow the caller to specify the resolution at which the line coordinates should be interpreted (converting to/from the underlying file resolution as needed).