### PR TITLE
build_image.py: `tag`->`tag_suffix`

### DIFF
--- a/build_image.py
+++ b/build_image.py
@@ -3,14 +3,20 @@
 import argparse
 import subprocess
 
-BUILD_COMMAND_TMPL = "docker build --network=host -t {REGION}-docker.pkg.dev/{PROJECT}/{REPO}/zetta_utils:py{PYTHON_VERSION}_{TAG} --build-arg PYTHON_VERSION={PYTHON_VERSION} -f docker/Dockerfile.{MODE} ."
-PUSH_COMMAND_TMPL = "docker push {REGION}-docker.pkg.dev/{PROJECT}/{REPO}/zetta_utils:py{PYTHON_VERSION}_{TAG}"
+BUILD_COMMAND_TMPL = "docker build --network=host -t {REGION}-docker.pkg.dev/{PROJECT}/{REPO}/zetta_utils:py{PYTHON_VERSION}_{TAG_SUFFIX} --build-arg PYTHON_VERSION={PYTHON_VERSION} -f docker/Dockerfile.{MODE} ."
+PUSH_COMMAND_TMPL = "docker push {REGION}-docker.pkg.dev/{PROJECT}/{REPO}/zetta_utils:py{PYTHON_VERSION}_{TAG_SUFFIX}"
 
 
 def main():
     parser = argparse.ArgumentParser(description="Build and push docker image.")
     parser.add_argument("--project", type=str, required=True, help="GCR project.")
-    parser.add_argument("--tag", "-t", type=str, required=True, help="Image tag name/version.")
+    parser.add_argument(
+        "--tag_suffix",
+        "-t",
+        type=str,
+        required=True,
+        help="Image tag suffix, used in addition with other flags.",
+    )
     parser.add_argument(
         "--mode",
         "-m",
@@ -27,15 +33,17 @@ def main():
         choices=["3.12", "3.11", "3.10"],
         help="Which python version to use for the image.",
     )
-    parser.add_argument("--region", type=str, default="us-central1", help="Artifact Registry region.")
+    parser.add_argument(
+        "--region", type=str, default="us-central1", help="Artifact Registry region."
+    )
     parser.add_argument("--repo", type=str, default="zutils", help="Artifact Registry repo name.")
 
     args = parser.parse_args()
 
     build_command = BUILD_COMMAND_TMPL
-    build_command = build_command.replace("{TAG}", args.tag)
+    build_command = build_command.replace("{TAG_SUFFIX}", args.tag_suffix)
     build_command = build_command.replace("{MODE}", args.mode)
-    build_command = build_command.replace("{PYTHON_VERSION}", args.python.replace('.', ''))
+    build_command = build_command.replace("{PYTHON_VERSION}", args.python.replace(".", ""))
     build_command = build_command.replace("{PROJECT}", args.project)
     build_command = build_command.replace("{REGION}", args.region)
     build_command = build_command.replace("{REPO}", args.repo)
@@ -43,8 +51,8 @@ def main():
     subprocess.call(build_command, shell=True)
 
     push_command = PUSH_COMMAND_TMPL
-    push_command = push_command.replace("{TAG}", args.tag)
-    push_command = push_command.replace("{PYTHON_VERSION}", args.python.replace('.', ''))
+    push_command = push_command.replace("{TAG_SUFFIX}", args.tag_suffix)
+    push_command = push_command.replace("{PYTHON_VERSION}", args.python.replace(".", ""))
     push_command = push_command.replace("{PROJECT}", args.project)
     push_command = push_command.replace("{REGION}", args.region)
     push_command = push_command.replace("{REPO}", args.repo)


### PR DESCRIPTION
It's unintuitive that the actual docker tag is not identical to `--tag` argument given to the script. Too much know-how