### PR TITLE
fix(simple_inference): ensure eval mode and disable autograd

### DIFF
--- a/zetta_utils/convnet/simple_inference_runner.py
+++ b/zetta_utils/convnet/simple_inference_runner.py
@@ -25,9 +25,10 @@ class SimpleInferenceRunner:  # pragma: no cover
             device = "cpu"
 
         # load model during the call _with caching_
-        model = convnet.utils.load_model(self.model_path, device=device, use_cache=True)
+        model = convnet.utils.load_model(self.model_path, device=device, use_cache=True).eval()
 
         if self.unsqueeze_to is not None:
             src = tensor_ops.unsqueeze_to(src, self.unsqueeze_to)
-        result = to_np(model(to_torch(src).to(device)))
+        with torch.no_grad():
+            result = to_np(model(to_torch(src).to(device)))
         return result


### PR DESCRIPTION
Speeds up computation, reduces memory consumption, and ensures correct behavior in case of BatchNorm/DropOut layers