### PR TITLE
Revert "chore: remove superfluous go / cue installs"

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -60,6 +60,14 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+      - name: Setup Go
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.4'
+      - name: Install CUE
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
+        run: go install cuelang.org/go/cmd/cue@v0.6.0
       - name: Install libboost
         if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
         run: sudo apt install libboost-dev
@@ -125,6 +133,14 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+      - name: Setup Go
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.4'
+      - name: Install CUE
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
+        run: go install cuelang.org/go/cmd/cue@v0.6.0
       - name: Install libboost
         if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
         run: sudo apt install libboost-dev
@@ -186,6 +202,14 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+      - name: Setup Go
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.4'
+      - name: Install CUE
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
+        run: go install cuelang.org/go/cmd/cue@v0.6.0
       - name: Install libboost
         if: ${{ steps.changed-py-files.outputs.any_changed == 'true' }}
         run: sudo apt install libboost-dev

--- a/.github/workflows/testing_integration.yaml
+++ b/.github/workflows/testing_integration.yaml
@@ -42,6 +42,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.18.4'
+      - name: Install CUE
+        run: go install cuelang.org/go/cmd/cue@v0.6.0
+      - name: Install libboost
+        run: sudo apt install libboost-dev
       - name: Install Python dependencies
         run: |
           python install_zutils.py --mode=all --dockerfile --skip_apt


### PR DESCRIPTION
Due to skip_apt, we actually need the go / cue installs.