### PR TITLE
Joe/precomp info fix

### DIFF
--- a/zetta_utils/layer/volumetric/annotation/backend.py
+++ b/zetta_utils/layer/volumetric/annotation/backend.py
@@ -388,10 +388,10 @@ class AnnotationLayerBackend(
                 3. The annotation IDs (also as uint64le)
 
         :param file_path: local file or GS path of file to write
-        :param lines: iterable of LineAnnotation objects
+        :param annotations: iterable of Annotation objects
         :param with_relations: whether to write out related IDs (by_id index only)
-        :param randomize: if True, the lines will be written in random
-                order (without mutating the lines parameter)
+        :param randomize: if True, the annotations will be written in random
+                order (without mutating the annotations parameter)
         """
         annotations = list(annotations)
         if randomize:
@@ -402,12 +402,13 @@ class AnnotationLayerBackend(
         # first write the count
         buffer.write(struct.pack("<Q", len(annotations)))
 
-        # then write the line data
+        # then write the annotation data
         for anno in annotations:
             anno.write(buffer, self.property_specs, self.relationships if with_relations else None)
 
         # finally write the ids at the end of the buffer
         for anno in annotations:
+            logger.info(f"writing annotation {anno.id}")
             buffer.write(struct.pack("<Q", anno.id))
 
         # Rewind buffer to the beginning, and write to disk
@@ -425,8 +426,8 @@ class AnnotationLayerBackend(
         """
         Write a set of line annotations to the file, adding to any already there.
 
-        :param annotations: sequence of LineAnnotations to add.
-        :param annotation_resolution: resolution of given LineAnnotation coordinates;
+        :param annotations: sequence of Annotations to add.
+        :param annotation_resolution: resolution of given Annotation coordinates;
         if not specified, assumes native coordinates (i.e. self.index.resolution)
         :param all_levels: if true, write to all spatial levels (chunk sizes).
             If false, write only to the lowest level (smallest chunks).

--- a/zetta_utils/layer/volumetric/annotation/build.py
+++ b/zetta_utils/layer/volumetric/annotation/build.py
@@ -190,8 +190,8 @@ def build_annotation_layer(  # pylint: disable=too-many-locals, too-many-branche
         file_chunk_sizes = [se.chunk_size for se in spatial_entries]
         if annotation_type and annotation_type != anno_type:
             raise IOError(
-                f"Given annotation_type {annotation_type} "
-                "does not match existing file type {anno_type}"
+                "Given annotation_type {annotation_type} "
+                f"does not match existing file type {anno_type}"
             )  # pragma: no cover
         annotation_type = anno_type
 
@@ -278,7 +278,10 @@ def build_annotation_layer(  # pylint: disable=too-many-locals, too-many-branche
         property_specs=final_property_specs,
         relationships=final_relationships,
     )
-    backend.write_info_file()
+
+    # Only write info file for modes that create or modify the layer
+    if mode in ("write", "replace", "update"):
+        backend.write_info_file()
 
     if mode == "replace":
         backend.clear()

--- a/zetta_utils/layer/volumetric/annotation/layer.py
+++ b/zetta_utils/layer/volumetric/annotation/layer.py
@@ -4,7 +4,6 @@ from typing import Sequence, Union
 
 import attrs
 
-from zetta_utils import builder, mazepa
 from zetta_utils.geometry import Vec3D
 from zetta_utils.layer.volumetric.annotation.backend import (
     Annotation,
@@ -81,11 +80,3 @@ class VolumetricAnnotationLayer(
         **kwargs,
     ):
         return attrs.evolve(self, **kwargs)  # pragma: no cover
-
-
-@builder.register("post_process_annotation_layer_flow")
-@mazepa.flow_schema
-def post_process_annotation_layer_flow(target: VolumetricAnnotationLayer):  # pragma: no cover
-    # As post-processing is inherently a single-process job, there's no need
-    # to make or yield a task for it; we can just run it directly on the head node.
-    target.backend.post_process()

--- a/zetta_utils/layer/volumetric/annotation/layer.py
+++ b/zetta_utils/layer/volumetric/annotation/layer.py
@@ -83,12 +83,9 @@ class VolumetricAnnotationLayer(
         return attrs.evolve(self, **kwargs)  # pragma: no cover
 
 
-@mazepa.taskable_operation
-def post_process_annotation_layer_op(target: VolumetricAnnotationLayer):  # pragma: no cover
-    target.backend.post_process()
-
-
 @builder.register("post_process_annotation_layer_flow")
 @mazepa.flow_schema
 def post_process_annotation_layer_flow(target: VolumetricAnnotationLayer):  # pragma: no cover
-    yield post_process_annotation_layer_op.make_task(target)
+    # As post-processing is inherently a single-process job, there's no need
+    # to make or yield a task for it; we can just run it directly on the head node.
+    target.backend.post_process()

--- a/zetta_utils/mazepa_layer_processing/__init__.py
+++ b/zetta_utils/mazepa_layer_processing/__init__.py
@@ -15,6 +15,8 @@ from .common import (
     build_chunked_apply_flow,
 )
 
+from . import annotation_postprocessing
+
 builder.register("mazepa.Executor")(mazepa.Executor)
 builder.register("mazepa.execute")(mazepa.execute)
 builder.register("mazepa.TaskRouter")(mazepa.TaskRouter)

--- a/zetta_utils/mazepa_layer_processing/annotation_postprocessing.py
+++ b/zetta_utils/mazepa_layer_processing/annotation_postprocessing.py
@@ -14,4 +14,6 @@ def post_process_annotation_layer_op(target: VolumetricAnnotationLayer):  # prag
 @builder.register("post_process_annotation_layer_flow")
 @mazepa.flow_schema
 def post_process_annotation_layer_flow(target: VolumetricAnnotationLayer):  # pragma: no cover
-    yield post_process_annotation_layer_op.make_task(target)
+    # As post-processing is inherently a single-process job, there's no need
+    # to make or yield a task for it; we can just run it directly on the head node.
+    target.backend.post_process()


### PR DESCRIPTION
Discovered in the course of testing something else that our precomputed annotations layer was overwriting the info file even when opened in "read only" mode.  This PR fixes that.

Also, there were some old comments that claimed parameters needed to be of type `LineAnnotation`, but that is no longer true; they can be any `Annotation` type.  So, I updated those comments too.