### PR TITLE
fix(execute_on_slurm): prevent Slurm worker shutdown during scheduling

### DIFF
--- a/zetta_utils/mazepa_addons/configurations/execute_on_slurm.py
+++ b/zetta_utils/mazepa_addons/configurations/execute_on_slurm.py
@@ -208,7 +208,7 @@ def get_slurm_contex_managers(
     )
 
     worker_command = get_mazepa_worker_command(
-        task_queue_spec, outcome_queue_spec, num_procs, semaphores_spec
+        task_queue_spec, outcome_queue_spec, num_procs, semaphores_spec, idle_timeout=86400
     )
     slurm_obj.add_cmd(init_command)
     slurm_obj.add_cmd(f"srun {worker_command}")


### PR DESCRIPTION
@akhileshh Is this still required, or was that fixed differently in the meantime? I believe my slurm workers where shutting down while the scheduler was busy uploading tasks for several minutes