### PR TITLE
feat(projection): First hit projection

### DIFF
--- a/tests/unit/tensor_ops/test_projection.py
+++ b/tests/unit/tensor_ops/test_projection.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+
+from zetta_utils.tensor_ops import projection
+
+from ..helpers import assert_array_equal
+
+
+@pytest.fixture
+def projection_data():
+    return np.array(
+        [
+            [
+                [[0, 1, 2], [0, 0, 3]],
+                [[0, 4, 0], [5, 0, 0]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture
+def projection_data_with_nan():
+    return np.array(
+        [
+            [
+                [[np.nan, 1, 2], [np.nan, np.nan, 3]],
+                [[np.nan, 4, np.nan], [5, np.nan, np.nan]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture
+def projection_expected_first():
+    return np.array(
+        [
+            [
+                [[1], [3]],
+                [[4], [5]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture
+def projection_expected_last():
+    return np.array(
+        [
+            [
+                [[2], [3]],
+                [[4], [5]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+
+@pytest.fixture
+def projection_data_all_bg():
+    return np.zeros((1, 2, 2, 3), dtype=np.float32)
+
+
+@pytest.fixture
+def projection_expected_all_bg():
+    return np.zeros((1, 2, 2, 1), dtype=np.float32)
+
+
+@pytest.mark.parametrize(
+    "data_name, kwargs, expected_name",
+    [
+        [
+            "projection_data",
+            {"bg_color": 0.0, "axis": 3, "direction": "first"},
+            "projection_expected_first",
+        ],
+        [
+            "projection_data_with_nan",
+            {"bg_color": np.nan, "axis": 3, "direction": "first"},
+            "projection_expected_first",
+        ],
+        [
+            "projection_data",
+            {"bg_color": 0.0, "axis": 3, "direction": "last"},
+            "projection_expected_last",
+        ],
+        [
+            "projection_data_all_bg",
+            {"bg_color": 0.0, "axis": 3, "direction": "first"},
+            "projection_expected_all_bg",
+        ],
+    ],
+)
+def test_first_hit_projection(data_name, kwargs, expected_name, request):
+    data = request.getfixturevalue(data_name)
+    result = projection.first_hit_projection(data, **kwargs)
+    expected = request.getfixturevalue(expected_name)
+    assert_array_equal(result, expected)

--- a/zetta_utils/tensor_ops/__init__.py
+++ b/zetta_utils/tensor_ops/__init__.py
@@ -16,4 +16,12 @@ from .mask import filter_cc  # , coarsen
 # Circular import otherwise
 from . import generators, traceback_supress
 
-from . import common, convert, label, mask, multitensor, normalization
+from . import (
+    common,
+    convert,
+    label,
+    mask,
+    multitensor,
+    normalization,
+    projection
+)

--- a/zetta_utils/tensor_ops/projection.py
+++ b/zetta_utils/tensor_ops/projection.py
@@ -1,0 +1,53 @@
+from typing import Literal, Sequence, Union
+
+import numpy as np
+from typeguard import typechecked
+
+from zetta_utils import builder
+from zetta_utils.tensor_ops import convert
+from zetta_utils.tensor_ops.common import supports_dict
+from zetta_utils.tensor_typing import TensorTypeVar
+
+
+@builder.register("first_hit_projection")
+@supports_dict
+@typechecked
+def first_hit_projection(
+    data: TensorTypeVar,
+    bg_color: Union[float, Sequence[float]] = 0.0,
+    axis: int = 3,
+    direction: Literal["first", "last"] = "first",
+    rtol: float = 1.0e-5,
+    atol: float = 1.0e-8,
+) -> TensorTypeVar:
+    """
+    Project 4D (CXYZ) to 3D (default CXY1) by taking first or last non-background value.
+
+    :param data:  Input tensor (CXYZ).
+    :param bg_color:  scalar or tuple/array of length C for per-channel background
+    :param axis:  axis along which to project (default 3 for z-axis)
+    :param direction:  'first' (default) or 'last'
+    :param rtol: The relative tolerance parameter (see np.isclose).
+    :param atol: The absolute tolerance parameter (see np.isclose).
+    :return: Projection with singleton dimension on projected axis
+    """
+    data_np = convert.to_np(data)
+
+    if direction == "last":
+        data_np = np.flip(data_np, axis=axis)
+
+    bg_color_broadcast = np.array(bg_color, dtype=data_np.dtype)
+    if bg_color_broadcast.ndim == 0:
+        bg_color_broadcast = np.full(data_np.shape[0], bg_color_broadcast)
+    bg_color_broadcast = bg_color_broadcast.reshape(-1, 1, 1, 1)
+
+    bg_channel_mask = np.isclose(data_np, bg_color_broadcast, rtol=rtol, atol=atol, equal_nan=True)
+    valid_voxel_mask = np.any(~bg_channel_mask, axis=0, keepdims=True)
+
+    first_idx = np.argmax(valid_voxel_mask, axis=axis, keepdims=True)
+    has_valid = np.any(valid_voxel_mask, axis=axis, keepdims=True)
+
+    projection = np.take_along_axis(data_np, first_idx, axis=axis)
+    projection = np.where(has_valid, projection, bg_color_broadcast)
+
+    return convert.astype(projection, reference=data)


### PR DESCRIPTION
Part of the block field stitching procedure for determining a residual correction field from multiple partial sections. Median is not ideal, because I want a specific section (the last) to precisely match and only fill in remaining gaps with information from previous (partial) sections.