### PR TITLE
chore(create_corgie_igneous_cluster): update k8s spec and permissions

### DIFF
--- a/scripts/gcp/autoprovision_config.yaml
+++ b/scripts/gcp/autoprovision_config.yaml
@@ -15,7 +15,23 @@ resourceLimits:
     maximum: 100
   - resourceType: 'nvidia-h100-mega-80gb'
     maximum: 100
+
 shieldedInstanceConfig:
   enableSecureBoot: false
   enableIntegrityMonitoring: true
+
 diskSizeGb: 64
+
+serviceAccount: "{CLUSTER_NAME}-worker@{PROJECT_NAME}.iam.gserviceaccount.com"
+locations:
+  - {NODE_LOCATIONS}
+
+autoprovisioningNodePoolDefaults:
+  oauthScopes:
+    - https://www.googleapis.com/auth/cloud-platform
+  upgradeSettings:
+    maxSurge: 0
+    maxUnavailable: 1
+  management:
+    autoUpgrade: true
+    autoRepair: true


### PR DESCRIPTION
* system node pool needs more disk space
* for use with VM (and GKE), need `roles/container.developer`
* monitoring and logging apparently need `roles/logging.logWriter`, `roles/monitoring.metricWriter`, `roles/stackdriver.resourceMetadata.writer`

* also combined the autoprovision settings with the cluster creation command