### PR TITLE
chore: remove fastmorph because it's only used in internal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,6 @@ tensor-ops = [
   "affine >= 2.3.1",
   "connected-components-3d == 3.23.0",
   "fastremap >= 1.17.7, < 2.0.0",
-  "fastmorph >= 1.6.1, < 2.0.0",
   "einops >= 0.4.1",
   "torchfields >= 0.1.2",
   "kornia >= 0.6.12",
@@ -286,7 +285,7 @@ ignore-imports = "yes"
 min-similarity-lines = 4
 
 [tool.pylint.main]
-extension-pkg-whitelist = "numpy,cc3d,fastremap,fastmorph"
+extension-pkg-whitelist = "numpy,cc3d,fastremap"
 ignore-paths = ["^docs/*", "^scripts/*", "^specs/*"]
 load-plugins = "pylint.extensions.no_self_use"
 


### PR DESCRIPTION
Sorry, another brain fart today. Fastmorph is only used in internal so it can go in internal's PR(#108). It's already part of it, so we can remove this duplicate.