### PR TITLE
Pin major package versions for stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,16 +18,16 @@ dependencies = [
   "fsspec >= 2022.8.2",
   "rich >= 12.6.0",
   "python-logging-loki >= 0.3.1",
-  "neuroglancer >= 2.32",
+  "neuroglancer == 2.41.2",
   "dill >= 0.3.6",
   "pyyaml ~= 6.0.1",
-  "requests >= 2.31.0",
+  "requests == 2.32.5",
   "requests-oauthlib ~= 1.3",
   "cloud-files >= 5.3.2",
   "packaging >= 23.2",
   "pdbp >= 1.5.3",
   "psutil >= 7.1.0",
-  "boto3 >= 1.38.15",
+  "boto3 == 1.40.67",
   "slack_sdk >= 3.31.0",
   "tabulate >= 0.9.0",
   "types-tabulate >= 0.1.0",
@@ -43,8 +43,8 @@ version = "0.0.2"
 
 [project.optional-dependencies]
 alignment = [
-  "opencv-python-headless >= 4.5.5",
-  "torch >= 2.0",
+  "opencv-python-headless == 4.11.0.86",
+  "torch == 2.9.0",
 ]
 all-cpu = ["zetta_utils[modules,docs,test]"]
 all = ["zetta_utils[all_cpu,gpu]"]
@@ -57,21 +57,21 @@ augmentations = [
 cli = ["click >= 8.0.1"]
 cloudvol = ["cloud-volume[all_codecs] == 12.6.2", "zetta_utils[tensor_ops]"]
 tensorstore = [
-  "boto3 >= 1.38.15",
-  "tensorstore >= 0.1.73",
+  "boto3 == 1.40.67",
+  "tensorstore == 0.1.78",
   "zetta_utils[tensor_ops]",
 ]
 chunkedgraph = [
   "click >= 8.0",
-  "protobuf>=4.22.0",
-  "requests>=2.25.0",
+  "protobuf == 6.33.0",
+  "requests == 2.32.5",
   "grpcio>=1.36.1",
-  "numpy>=2.2.5",                  # reinstall avoids "Core dumped" for tensorstore and neuroglancer?!
-  "pandas",
+  "numpy == 2.3.4",                  # reinstall avoids "Core dumped" for tensorstore and neuroglancer?!
+  "pandas == 2.3.3",
   "networkx>=2.1",
   "google-cloud-bigtable>=0.33.0",
   "google-cloud-datastore>=1.8",
-  "flask",
+  "flask == 2.2.5",
   "flask_cors",
   "python-json-logger",
   "redis",
@@ -94,7 +94,7 @@ chunkedgraph = [
   # Note: graph_tool must be installed separately via conda:
   # conda install -c conda-forge graph-tool-base
 ]
-convnet = ["torch >= 2.0", "artificery >= 0.0.3.3", "onnx2torch", "nvidia-ml-py >= 13.580"]
+convnet = ["torch == 2.9.0", "artificery >= 0.0.3.3", "onnx2torch", "nvidia-ml-py >= 13.580"]
 databackends = ["google-cloud-datastore", "google-cloud-firestore"]
 docs = [
   "piccolo_theme >= 0.24.0",
@@ -126,12 +126,12 @@ mazepa = [
   "chardet >= 5.0.0, < 6.0.0",
   "coolname >= 1.1.0",
   "task-queue >= 2.12.0",
-  "boto3 >= 1.38.15",
+  "boto3 == 1.40.67",
   "xxhash ~= 3.2.0",
 ]
 mazepa-addons = [
   "zetta_utils[mazepa]",
-  "kubernetes >= 25.3.0",
+  "kubernetes == 34.1.0",
   "awscli ~= 1.29",
   "google-cloud-container",
   "google-api-python-client",
@@ -167,7 +167,7 @@ modules = [
   "zetta_utils[skeletonization]",
   "zetta_utils[chunkedgraph]",
 ]
-montaging = ["zetta_utils[cloudvol, databackends, mazepa]", "torch >= 2.0"]
+montaging = ["zetta_utils[cloudvol, databackends, mazepa]", "torch == 2.9.0"]
 public = [
   # put them in order of dependencies
   "zetta_utils[tensor_ops, viz, cli, gcs, slurm]",
@@ -178,9 +178,9 @@ public = [
 ]
 segmentation = [
   "zetta_utils[tensor_ops]",
-  "onnx >= 1.13.0",
+  "onnx == 1.19.1",
   "onnx2torch",
-  "scikit-learn >= 1.2.2",
+  "scikit-learn == 1.7.2",
   "networkx",
   "lsds @ git+https://github.com/ZettaAI/lsd.git@cebe976",
   "abiss @ git+https://github.com/ZettaAI/abiss.git@1d1fc27",
@@ -192,10 +192,10 @@ skeletonization = [
   "mapbuffer >= 0.7.2",
   "shard-computer >= 1.1.1",
   "kimimaro>=4.0.2",
-  "scikit-learn >= 1.2.2",
+  "scikit-learn == 1.7.2",
 ]
 slurm = ["simple_slurm"]
-sql = ["SQLAlchemy >= 2.0.36", "psycopg2-binary >= 2.9.0"]
+sql = ["SQLAlchemy == 2.0.44", "psycopg2-binary >= 2.9.0"]
 tensor-ops = [
   "zetta_utils[tensor_typing]",
   "tinybrain >= 1.7.0",
@@ -206,11 +206,11 @@ tensor-ops = [
   "einops >= 0.4.1",
   "torchfields >= 0.1.2",
   "kornia >= 0.6.12",
-  "opencv-python-headless >= 4.5.5",
-  "scikit-image >= 0.19.3",
+  "opencv-python-headless == 4.11.0.86",
+  "scikit-image == 0.25.2",
 ]
 
-tensor-typing = ["torch >= 2.0", "numpy"]
+tensor-typing = ["torch == 2.9.0", "numpy == 2.3.4"]
 
 test = [
   "zetta_utils[types]",
@@ -234,12 +234,12 @@ test = [
 ]
 training = [
   "zetta_utils[tensor_ops,cloudvol,convnet,viz,gcs,augmentations]",
-  "torch >= 2.0",
-  "lightning[pytorch] ~= 2.2",
+  "torch == 2.9.0",
+  "lightning[pytorch] == 2.5.6",
   "torchmetrics == 0.11.4",
-  "wandb >= 0.13.1",
-  "kubernetes",
-  "onnx >= 1.13.0",
+  "wandb == 0.22.3",
+  "kubernetes == 34.1.0",
+  "onnx == 1.19.1",
   "zetta_utils[mazepa]",
 ]
 types = [
@@ -250,9 +250,9 @@ types = [
 ]
 viz = [
   "zetta_utils[tensor_ops]",
-  "matplotlib >= 3.5.2",
+  "matplotlib == 3.10.7",
   "ipywidgets >= 7.7.0",
-  "opencv-python-headless >= 4.5.5",
+  "opencv-python-headless == 4.11.0.86",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Pin critical packages to specific versions.

Pinned packages:
- **torch**: 2.9.0
- **numpy**: 2.3.4
- **neuroglancer**: 2.41.2
- **tensorstore**: 0.1.78
- **scikit-learn**: 1.7.2
- **pandas**: 2.3.3
- **matplotlib**: 3.10.7
- **opencv-python-headless**: 4.11.0.86
- **lightning**: 2.5.6
- **wandb**: 0.22.3
- **onnx**: 1.19.1
- **requests**: 2.32.5
- **boto3**: 1.40.67
- **flask**: 2.2.5
- **kubernetes**: 34.1.0
- **protobuf**: 6.33.0
- **SQLAlchemy**: 2.0.44
- **scikit-image**: 0.25.2