### PR TITLE
Reduce Docker build context by excluding large directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,13 @@
 specs/**
+scripts/
+notebooks/
+layer/
+tests/
+*.tif
+*.txt
+*.json
+*.csv
+*.log
 
 # Traing data logging
 **/wandb/**


### PR DESCRIPTION
## Summary
- Add , , ,  directories to 
- Add data file patterns (, , , , ) to 
- Reduces Docker build context from ~35GB to ~87MB

## Test plan
- [x] Verified Docker build completes successfully with reduced context
- [x] Image builds and pushes to artifact registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)