### PR TITLE
fix: reset signal handlers for direct fork pools

### DIFF
--- a/zetta_utils/common/__init__.py
+++ b/zetta_utils/common/__init__.py
@@ -10,5 +10,5 @@ from .misc import get_unique_id
 from .path import abspath, is_local
 from .pprint import lrpad
 from .resource_monitor import monitor_resources
-from .signal_handlers import custom_signal_handler_ctx
+from .signal_handlers import custom_signal_handler_ctx, reset_signal_handlers
 from .timer import RepeatTimer, Timer

--- a/zetta_utils/common/signal_handlers.py
+++ b/zetta_utils/common/signal_handlers.py
@@ -2,6 +2,10 @@ import signal
 from contextlib import contextmanager
 
 
+def reset_signal_handlers():  # pragma: no cover
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
 @contextmanager
 def custom_signal_handler_ctx(fn, target_signal):  # pragma: no cover
     original_signal_handler = signal.getsignal(target_signal)  # eg signal.SIGINT

--- a/zetta_utils/geometry/bbox_strider.py
+++ b/zetta_utils/geometry/bbox_strider.py
@@ -9,6 +9,7 @@ import attrs
 from typeguard import typechecked
 
 from zetta_utils import MULTIPROCESSING_NUM_TASKS_THRESHOLD, builder, log
+from zetta_utils.common import reset_signal_handlers
 from zetta_utils.geometry.vec import VEC3D_PRECISION
 
 from . import Vec3D
@@ -241,7 +242,9 @@ class BBoxStrider:
     def get_all_chunk_bboxes(self) -> List[BBox3D]:
         """Get all of the chunks."""
         if self.num_chunks > MULTIPROCESSING_NUM_TASKS_THRESHOLD:
-            with multiprocessing.get_context("fork").Pool() as pool_obj:
+            with multiprocessing.get_context("fork").Pool(
+                initializer=reset_signal_handlers
+            ) as pool_obj:
                 result = pool_obj.map(self.get_nth_chunk_bbox, range(self.num_chunks))
         else:
             result = [

--- a/zetta_utils/mazepa_addons/configurations/worker_pool.py
+++ b/zetta_utils/mazepa_addons/configurations/worker_pool.py
@@ -4,7 +4,6 @@ import contextlib
 import logging
 import multiprocessing
 import os
-import signal
 import sys
 import time
 from contextlib import ExitStack
@@ -13,7 +12,7 @@ from itertools import repeat
 import pebble
 
 from zetta_utils import builder, log, try_load_train_inference
-from zetta_utils.common import monitor_resources
+from zetta_utils.common import monitor_resources, reset_signal_handlers
 from zetta_utils.mazepa import SemaphoreType, Task, configure_semaphores, run_worker
 from zetta_utils.mazepa.task_outcome import OutcomeReport
 from zetta_utils.message_queues import FileQueue, SQSQueue
@@ -43,8 +42,7 @@ def worker_init(
 ) -> None:
     # Reset signal handlers inherited from parent to default behavior
     # This prevents parent's signal handlers from interfering with worker cleanup
-    signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    reset_signal_handlers()
     # For Kubernetes compatibility, ensure unbuffered output
     os.environ["PYTHONUNBUFFERED"] = "1"
     if suppress_worker_logs:

--- a/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py
@@ -16,6 +16,7 @@ from typeguard import suppress_type_checks
 from typing_extensions import ParamSpec
 
 from zetta_utils import MULTIPROCESSING_NUM_TASKS_THRESHOLD, log, mazepa
+from zetta_utils.common import reset_signal_handlers
 from zetta_utils.geometry import Vec3D
 from zetta_utils.layer.volumetric import (
     VolumetricBasedLayerProtocol,
@@ -484,7 +485,9 @@ class VolumetricApplyFlowSchema(Generic[P, R_co]):
         op_kwargs: P.kwargs,
     ) -> List[mazepa.tasks.Task[R_co]]:
         if len(idx_chunks) > MULTIPROCESSING_NUM_TASKS_THRESHOLD:
-            with multiprocessing.get_context("fork").Pool() as pool_obj:
+            with multiprocessing.get_context("fork").Pool(
+                initializer=reset_signal_handlers
+            ) as pool_obj:
                 tasks = pool_obj.map(
                     self._make_task,
                     zip(idx_chunks, itertools.repeat(dst), itertools.repeat(op_kwargs)),
@@ -592,7 +595,9 @@ class VolumetricApplyFlowSchema(Generic[P, R_co]):
                 next_chunk_id = task_idxs[-1, -1, -1].chunk_id + self.l0_chunks_per_task
 
                 if len(task_idxs) > MULTIPROCESSING_NUM_TASKS_THRESHOLD:
-                    with multiprocessing.get_context("fork").Pool() as pool_obj:
+                    with multiprocessing.get_context("fork").Pool(
+                        initializer=reset_signal_handlers
+                    ) as pool_obj:
                         tasks_split = pool_obj.map(
                             self._make_task,
                             zip(


### PR DESCRIPTION
The head node only uses the fork pool, in which case the signal handling fix for spawned workers doesn't work. This addresses it by resetting the signal handlers for those.