### PR TITLE
perf: disable LRU cache for intermediaries / code cleanup

### DIFF
--- a/zetta_utils/layer/volumetric/cloudvol/backend.py
+++ b/zetta_utils/layer/volumetric/cloudvol/backend.py
@@ -21,8 +21,17 @@ from zetta_utils.geometry import Vec3D
 from ...precomputed import PrecomputedInfoSpec, get_info
 from .. import VolumetricBackend, VolumetricIndex
 
-_cv_cache: cachetools.LRUCache = cachetools.LRUCache(maxsize=2048)
-_cv_cached: Dict[str, set] = {}
+
+class _CVLRUCache(cachetools.LRUCache):
+    """LRU cache that clears CloudVolume internal LRU on eviction."""
+
+    def popitem(self):
+        key, cvol = super().popitem()
+        cvol.image.lru.clear()
+        return key, cvol
+
+
+_cv_cache: _CVLRUCache = _CVLRUCache(maxsize=36)
 
 IN_MEM_CACHE_NUM_BYTES_PER_CV = 1 * 1024 ** 3
 
@@ -86,22 +95,20 @@ def _get_cv_cached(
             **kwargs,
         )
     _cv_cache[cache_key] = result
-    if path_ not in _cv_cached:
-        _cv_cached[path_] = set()
-    _cv_cached[path_].add((resolution, kwargs_key))
     return result
 
 
 def _clear_cv_cache(path: str | None = None) -> None:  # pragma: no cover
     if path is None:
-        _cv_cached.clear()
+        for cvol in _cv_cache.values():
+            cvol.image.lru.clear()
         _cv_cache.clear()
         return
     path_ = abspath(path)
-    resolution_kwargs_pairs = _cv_cached.pop(path_, None)
-    if resolution_kwargs_pairs is not None:
-        for resolution, kwargs_key in resolution_kwargs_pairs:
-            _cv_cache.pop((path_, resolution, kwargs_key), None)
+    keys_to_remove = [k for k in _cv_cache if k[0] == path_]
+    for k in keys_to_remove:
+        _cv_cache[k].image.lru.clear()
+        _cv_cache.pop(k, None)
 
 
 @attrs.mutable
@@ -252,12 +259,11 @@ class CVBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
 
     def clear_cache(self) -> None:  # pragma: no cover
         path_ = abspath(self.path)
-        resolution_kwargs_pairs = _cv_cached.get(path_, set())
-        for resolution, kwargs_key in resolution_kwargs_pairs:
-            cache_key = (path_, resolution, kwargs_key)
-            if cache_key in _cv_cache:
-                _cv_cache[cache_key].image.lru.clear()
-        _clear_cv_cache(self.path)
+        kwargs_key = _serialize_kwargs(self.cv_kwargs)
+        for key in list(_cv_cache):
+            if key[0] == path_ and key[2] == kwargs_key:
+                _cv_cache[key].image.lru.clear()
+                _cv_cache.pop(key, None)
 
     def read(self, idx: VolumetricIndex) -> npt.NDArray:
         # Data out: cxyz
@@ -403,7 +409,7 @@ class CVBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
         return self.name
 
     def delete(self):
-        self.clear_cache()
+        _clear_cv_cache(self.path)
         gc.collect()
 
         path = abspath(self.path)

--- a/zetta_utils/layer/volumetric/cloudvol/backend.py
+++ b/zetta_utils/layer/volumetric/cloudvol/backend.py
@@ -309,7 +309,8 @@ class CVBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
         "voxel_offset_res" = (voxel_offset, resolution): Tuple[Vec3D[int], Vec3D]
         "chunk_size_res" = (chunk_size, resolution): Tuple[Vec3D[int], Vec3D]
         "dataset_size_res" = (dataset_size, resolution): Tuple[Vec3D[int], Vec3D]
-        "allow_cache" = value: Union[bool, str]
+        "allow_cache" = value: Union[bool, str] # NOTE: This is the on-disk cache
+        "cache_bytes_limit" = value: int        # NOTE: This is for LRU cache
         """
         assert self.info_spec is not None
 
@@ -325,8 +326,9 @@ class CVBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
             "voxel_offset_res",
             "chunk_size_res",
             "dataset_size_res",
+            "cache_bytes_limit",
         ]
-        keys_to_kwargs = {"name": "path"}
+        keys_to_kwargs = {"name": "path", "cache_bytes_limit": "cache_bytes_limit"}
         keys_to_infospec_fn = {
             "voxel_offset_res": info_spec.set_voxel_offset,
             "chunk_size_res": info_spec.set_chunk_size,

--- a/zetta_utils/layer/volumetric/tensorstore/backend.py
+++ b/zetta_utils/layer/volumetric/tensorstore/backend.py
@@ -279,6 +279,7 @@ class TSBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
         "voxel_offset_res" = (voxel_offset, resolution): Tuple[Vec3D[int], Vec3D]
         "chunk_size_res" = (chunk_size, resolution): Tuple[Vec3D[int], Vec3D]
         "dataset_size_res" = (dataset_size, resolution): Tuple[Vec3D[int], Vec3D]
+        "cache_bytes_limit" = value: int - unused for TensorStoreBackend, ignored
         """
         # TODO: implement proper allow_cache logic
         assert self.info_spec is not None
@@ -294,6 +295,7 @@ class TSBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
             "chunk_size_res",
             "dataset_size_res",
             "use_compression",
+            "cache_bytes_limit",
         ]
 
         keys_to_infospec_fn = {
@@ -306,6 +308,7 @@ class TSBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
             "name": "path",
             "enforce_chunk_aligned_writes": "enforce_chunk_aligned_writes",
             "overwrite_partial_chunks": "overwrite_partial_chunks",
+            "cache_bytes_limit": "cache_bytes_limit",
         }
 
         evolve_kwargs = {}

--- a/zetta_utils/layer/volumetric/tensorstore/backend.py
+++ b/zetta_utils/layer/volumetric/tensorstore/backend.py
@@ -151,7 +151,7 @@ class TSBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
     @name.setter
     def name(self, name: str) -> None:  # pragma: no cover
         raise NotImplementedError(
-            "cannot set `name` for CVBackend directly;"
+            "cannot set `name` for TSBackend directly;"
             " use `backend.with_changes(name='name')` instead."
         )
 
@@ -183,12 +183,12 @@ class TSBackend(VolumetricBackend):  # pylint: disable=too-few-public-methods
 
     @property
     def allow_cache(self) -> bool:  # pragma: no cover
-        return True
+        return False
 
     @allow_cache.setter
     def allow_cache(self, value: Union[bool, str]) -> None:  # pragma: no cover
         raise NotImplementedError(
-            "cannot set `allow_cache` for CVBackend directly;"
+            "cannot set `allow_cache` for TSBackend directly;"
             " use `backend.with_changes(allow_cache=value:Union[bool, str])` instead."
         )
 

--- a/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py
+++ b/zetta_utils/mazepa_layer_processing/common/volumetric_apply_flow.py
@@ -248,6 +248,7 @@ class VolumetricApplyFlowSchema(Generic[P, R_co]):
             overwrite_partial_chunks=True,
             allow_cache=allow_cache,
             use_compression=False,
+            cache_bytes_limit=0,
         )
         return dst.with_procs(read_procs=()).with_changes(backend=backend_temp)
 


### PR DESCRIPTION
  1. **823ba63a** feat: add cache_bytes_limit to backend with_changes                                                                                                                                                                                                                                                         
  2. **81d82072** perf: disable LRU cache for intermediary layers
  3. **ba2d63b6** chore: simplify cv_cache logic                                                                                                                                                                                                                                                                              
  4. **bf66bf09** chore: fix TSBackend docstrings and allow_cache default  
  
 Lowered the default number of CVs in cache from 2048 to 36 since CVs were taking up memory.