### PR TITLE
refactor: replace pebble process timeout with signal.alarm

### DIFF
--- a/tests/unit/mazepa/test_task.py
+++ b/tests/unit/mazepa/test_task.py
@@ -56,9 +56,9 @@ def test_make_taskable_operation() -> None:
 
 
 def test_task_runtime_limit() -> None:
-    @taskable_operation(runtime_limit_sec=0.1)
+    @taskable_operation(runtime_limit_sec=1)
     def dummy_task_fn():
-        time.sleep(0.3)
+        time.sleep(3)
 
     assert isinstance(dummy_task_fn, TaskableOperation)
     task = dummy_task_fn.make_task()
@@ -68,12 +68,12 @@ def test_task_runtime_limit() -> None:
 
 
 def test_task_no_handle_exc() -> None:
-    @taskable_operation(runtime_limit_sec=0.1)
+    @taskable_operation(runtime_limit_sec=1)
     def dummy_task_fn():
         raise DummyException()
 
     assert isinstance(dummy_task_fn, TaskableOperation)
     task = dummy_task_fn.make_task()
     assert isinstance(task, Task)
-    with pytest.raises(Exception):
+    with pytest.raises(DummyException):
         task(debug=False, handle_exceptions=False)

--- a/zetta_utils/mazepa/tasks.py
+++ b/zetta_utils/mazepa/tasks.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import functools
+import signal
 import sys
 import time
 import traceback
 import uuid
-from concurrent.futures import TimeoutError as PebbleTimeoutError
 from typing import (
     Any,
     Callable,
@@ -20,7 +20,6 @@ from typing import (
 )
 
 import attrs
-from pebble import concurrent
 from typing_extensions import ParamSpec
 
 from zetta_utils import log
@@ -75,13 +74,17 @@ class Task(Generic[R_co]):  # pylint: disable=too-many-instance-attributes
         if debug or self.runtime_limit_sec is None:
             return_value = self.fn(*self.args, **self.kwargs)
         else:
-            future = concurrent.process(timeout=self.runtime_limit_sec)(self.fn)(
-                *self.args, **self.kwargs
-            )
+
+            def _timeout_handler(signum, frame):
+                raise exceptions.MazepaTimeoutError(f"Task '{self.id_}' took too long.")
+
+            old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+            signal.alarm(int(self.runtime_limit_sec))
             try:
-                return_value = future.result()
-            except PebbleTimeoutError as e:
-                raise exceptions.MazepaTimeoutError(f"Task '{self.id_}' took too long.") from e
+                return_value = self.fn(*self.args, **self.kwargs)
+            finally:
+                signal.alarm(0)
+                signal.signal(signal.SIGALRM, old_handler)
         return return_value
 
     def __call__(self, debug: bool = True, handle_exceptions: bool = True) -> TaskOutcome[R_co]:


### PR DESCRIPTION
Use SIGALRM in the worker process instead of spawning a separate process for task timeout enforcement. This eliminates one process creation per timed task execution.