### PR TITLE
feat: add per-worker-type stats table to aggregate_pod_stats log output

### DIFF
--- a/tests/unit/cloud_management/resource_allocation/k8s/test_gcs_tracker.py
+++ b/tests/unit/cloud_management/resource_allocation/k8s/test_gcs_tracker.py
@@ -479,7 +479,7 @@ class TestCollectResourceStats:
     def test_returns_parsed_dict_from_valid_file(self, tmp_path, mocker):
         summary = {
             "cpu": {"avg_percent": 75.0, "max_percent": 95.0},
-            "memory": {"total_gb": 64.0, "avg_percent": 60.0},
+            "memory": {"total_gib": 64.0, "avg_percent": 60.0},
         }
         path = tmp_path / "resource_stats.json"
         path.write_text(json.dumps(summary))

--- a/zetta_utils/common/resource_monitor.py
+++ b/zetta_utils/common/resource_monitor.py
@@ -61,9 +61,9 @@ class ResourceMonitor:  # pragma: no cover # logging only
         """Get current memory usage information."""
         mem = psutil.virtual_memory()
         return {
-            "total_gb": mem.total / (1024 ** 3),
-            "used_gb": mem.used / (1024 ** 3),
-            "available_gb": mem.available / (1024 ** 3),
+            "total_gib": mem.total / (1024 ** 3),
+            "used_gib": mem.used / (1024 ** 3),
+            "available_gib": mem.available / (1024 ** 3),
             "percent": mem.percent,
         }
 
@@ -131,9 +131,9 @@ class ResourceMonitor:  # pragma: no cover # logging only
                         "gpu_id": i,
                         "gpu_percent": util.gpu,
                         "memory_percent": util.memory,
-                        "memory_total_gb": mem_info.total / (1024 ** 3),
-                        "memory_used_gb": mem_info.used / (1024 ** 3),
-                        "memory_free_gb": mem_info.free / (1024 ** 3),
+                        "memory_total_gib": mem_info.total / (1024 ** 3),
+                        "memory_used_gib": mem_info.used / (1024 ** 3),
+                        "memory_free_gib": mem_info.free / (1024 ** 3),
                     }
                 )
             except Exception as e:  # pylint:disable=broad-except
@@ -165,47 +165,47 @@ class ResourceMonitor:  # pragma: no cover # logging only
         ):
             time_delta = current_time - self.prev_time
             if time_delta > 0:
-                # Calculate disk I/O rates (MB/s)
-                disk_read_rate_mbps = (
+                # Calculate disk I/O rates (MiB/s)
+                disk_read_rate_mibps = (
                     (stats["disk_io"]["read_bytes"] - self.prev_disk_io["read_bytes"])
                     / (1024 ** 2)
                     / time_delta
                 )
-                disk_write_rate_mbps = (
+                disk_write_rate_mibps = (
                     (stats["disk_io"]["write_bytes"] - self.prev_disk_io["write_bytes"])
                     / (1024 ** 2)
                     / time_delta
                 )
 
-                # Calculate network I/O rates (MB/s)
-                net_recv_rate_mbps = (
+                # Calculate network I/O rates (MiB/s)
+                net_recv_rate_mibps = (
                     (stats["network"]["bytes_recv"] - self.prev_net_io["bytes_recv"])
                     / (1024 ** 2)
                     / time_delta
                 )
-                net_send_rate_mbps = (
+                net_send_rate_mibps = (
                     (stats["network"]["bytes_sent"] - self.prev_net_io["bytes_sent"])
                     / (1024 ** 2)
                     / time_delta
                 )
 
                 # Add rates to stats
-                stats["disk_io"]["read_rate_mbps"] = disk_read_rate_mbps
-                stats["disk_io"]["write_rate_mbps"] = disk_write_rate_mbps
-                stats["network"]["recv_rate_mbps"] = net_recv_rate_mbps
-                stats["network"]["send_rate_mbps"] = net_send_rate_mbps
+                stats["disk_io"]["read_rate_mibps"] = disk_read_rate_mibps
+                stats["disk_io"]["write_rate_mibps"] = disk_write_rate_mibps
+                stats["network"]["recv_rate_mibps"] = net_recv_rate_mibps
+                stats["network"]["send_rate_mibps"] = net_send_rate_mibps
             else:
                 # First measurement or no time elapsed, set rates to 0
-                stats["disk_io"]["read_rate_mbps"] = 0.0
-                stats["disk_io"]["write_rate_mbps"] = 0.0
-                stats["network"]["recv_rate_mbps"] = 0.0
-                stats["network"]["send_rate_mbps"] = 0.0
+                stats["disk_io"]["read_rate_mibps"] = 0.0
+                stats["disk_io"]["write_rate_mibps"] = 0.0
+                stats["network"]["recv_rate_mibps"] = 0.0
+                stats["network"]["send_rate_mibps"] = 0.0
         else:
             # First measurement, no rates available
-            stats["disk_io"]["read_rate_mbps"] = 0.0
-            stats["disk_io"]["write_rate_mbps"] = 0.0
-            stats["network"]["recv_rate_mbps"] = 0.0
-            stats["network"]["send_rate_mbps"] = 0.0
+            stats["disk_io"]["read_rate_mibps"] = 0.0
+            stats["disk_io"]["write_rate_mibps"] = 0.0
+            stats["network"]["recv_rate_mibps"] = 0.0
+            stats["network"]["send_rate_mibps"] = 0.0
 
         # Update previous values for next calculation
         self.prev_disk_io = stats["disk_io"].copy()
@@ -244,8 +244,8 @@ class ResourceMonitor:  # pragma: no cover # logging only
             return sorted_values[index]
 
         cpu_values = [s["cpu_percent"] for s in self.samples]
-        mem_used = [s["memory"]["used_gb"] for s in self.samples]
-        mem_total = self.samples[0]["memory"]["total_gb"] if self.samples else 0.0
+        mem_used = [s["memory"]["used_gib"] for s in self.samples]
+        mem_total = self.samples[0]["memory"]["total_gib"] if self.samples else 0.0
         mem_percent = [s["memory"]["percent"] for s in self.samples]
 
         # Disk I/O stats (calculate deltas for totals)
@@ -260,11 +260,11 @@ class ResourceMonitor:  # pragma: no cover # logging only
         net_packets_sent = [s["network"]["packets_sent"] for s in self.samples]
         net_packets_recv = [s["network"]["packets_recv"] for s in self.samples]
 
-        # I/O rates (per-interval rates in MB/s)
-        disk_read_rate_mbps = [s["disk_io"]["read_rate_mbps"] for s in self.samples]
-        disk_write_rate_mbps = [s["disk_io"]["write_rate_mbps"] for s in self.samples]
-        net_recv_rate_mbps = [s["network"]["recv_rate_mbps"] for s in self.samples]
-        net_send_rate_mbps = [s["network"]["send_rate_mbps"] for s in self.samples]
+        # I/O rates (per-interval rates in MiB/s)
+        disk_read_rate_mibps = [s["disk_io"]["read_rate_mibps"] for s in self.samples]
+        disk_write_rate_mibps = [s["disk_io"]["write_rate_mibps"] for s in self.samples]
+        net_recv_rate_mibps = [s["network"]["recv_rate_mibps"] for s in self.samples]
+        net_send_rate_mibps = [s["network"]["send_rate_mibps"] for s in self.samples]
 
         duration_seconds = len(self.samples) * self.log_interval_seconds
 
@@ -278,21 +278,21 @@ class ResourceMonitor:  # pragma: no cover # logging only
                 "p25_percent": calculate_25th_percentile(cpu_values),
             },
             "memory": {
-                "total_gb": mem_total,
-                "avg_used_gb": calculate_avg(mem_used),
-                "max_used_gb": calculate_max(mem_used),
-                "min_used_gb": calculate_min(mem_used),
-                "p25_used_gb": calculate_25th_percentile(mem_used),
+                "total_gib": mem_total,
+                "avg_used_gib": calculate_avg(mem_used),
+                "max_used_gib": calculate_max(mem_used),
+                "min_used_gib": calculate_min(mem_used),
+                "p25_used_gib": calculate_25th_percentile(mem_used),
                 "avg_percent": calculate_avg(mem_percent),
                 "max_percent": calculate_max(mem_percent),
                 "min_percent": calculate_min(mem_percent),
                 "p25_percent": calculate_25th_percentile(mem_percent),
             },
             "disk_io": {
-                "total_read_gb": (disk_read_bytes[-1] - disk_read_bytes[0]) / (1024 ** 3)
+                "total_read_gib": (disk_read_bytes[-1] - disk_read_bytes[0]) / (1024 ** 3)
                 if len(disk_read_bytes) > 1
                 else 0.0,
-                "total_write_gb": (disk_write_bytes[-1] - disk_write_bytes[0]) / (1024 ** 3)
+                "total_write_gib": (disk_write_bytes[-1] - disk_write_bytes[0]) / (1024 ** 3)
                 if len(disk_write_bytes) > 1
                 else 0.0,
                 "total_read_ops": disk_read_count[-1] - disk_read_count[0]
@@ -301,32 +301,32 @@ class ResourceMonitor:  # pragma: no cover # logging only
                 "total_write_ops": disk_write_count[-1] - disk_write_count[0]
                 if len(disk_write_count) > 1
                 else 0,
-                "avg_read_rate_mbps": (
+                "avg_read_rate_mibps": (
                     (disk_read_bytes[-1] - disk_read_bytes[0])
                     / (1024 ** 2)
                     / max(duration_seconds, 1)
                 )
                 if len(disk_read_bytes) > 1
                 else 0.0,
-                "avg_write_rate_mbps": (
+                "avg_write_rate_mibps": (
                     (disk_write_bytes[-1] - disk_write_bytes[0])
                     / (1024 ** 2)
                     / max(duration_seconds, 1)
                 )
                 if len(disk_write_bytes) > 1
                 else 0.0,
-                "avg_read_rate_interval_mbps": calculate_avg(disk_read_rate_mbps),
-                "max_read_rate_mbps": calculate_max(disk_read_rate_mbps),
-                "p25_read_rate_mbps": calculate_25th_percentile(disk_read_rate_mbps),
-                "avg_write_rate_interval_mbps": calculate_avg(disk_write_rate_mbps),
-                "max_write_rate_mbps": calculate_max(disk_write_rate_mbps),
-                "p25_write_rate_mbps": calculate_25th_percentile(disk_write_rate_mbps),
+                "avg_read_rate_interval_mibps": calculate_avg(disk_read_rate_mibps),
+                "max_read_rate_mibps": calculate_max(disk_read_rate_mibps),
+                "p25_read_rate_mibps": calculate_25th_percentile(disk_read_rate_mibps),
+                "avg_write_rate_interval_mibps": calculate_avg(disk_write_rate_mibps),
+                "max_write_rate_mibps": calculate_max(disk_write_rate_mibps),
+                "p25_write_rate_mibps": calculate_25th_percentile(disk_write_rate_mibps),
             },
             "network": {
-                "total_bytes_sent_gb": (net_bytes_sent[-1] - net_bytes_sent[0]) / (1024 ** 3)
+                "total_bytes_sent_gib": (net_bytes_sent[-1] - net_bytes_sent[0]) / (1024 ** 3)
                 if len(net_bytes_sent) > 1
                 else 0.0,
-                "total_bytes_recv_gb": (net_bytes_recv[-1] - net_bytes_recv[0]) / (1024 ** 3)
+                "total_bytes_recv_gib": (net_bytes_recv[-1] - net_bytes_recv[0]) / (1024 ** 3)
                 if len(net_bytes_recv) > 1
                 else 0.0,
                 "total_packets_sent": net_packets_sent[-1] - net_packets_sent[0]
@@ -335,26 +335,26 @@ class ResourceMonitor:  # pragma: no cover # logging only
                 "total_packets_recv": net_packets_recv[-1] - net_packets_recv[0]
                 if len(net_packets_recv) > 1
                 else 0,
-                "avg_send_rate_mbps": (
+                "avg_send_rate_mibps": (
                     (net_bytes_sent[-1] - net_bytes_sent[0])
                     / (1024 ** 2)
                     / max(duration_seconds, 1)
                 )
                 if len(net_bytes_sent) > 1
                 else 0.0,
-                "avg_recv_rate_mbps": (
+                "avg_recv_rate_mibps": (
                     (net_bytes_recv[-1] - net_bytes_recv[0])
                     / (1024 ** 2)
                     / max(duration_seconds, 1)
                 )
                 if len(net_bytes_recv) > 1
                 else 0.0,
-                "avg_recv_rate_interval_mbps": calculate_avg(net_recv_rate_mbps),
-                "max_recv_rate_mbps": calculate_max(net_recv_rate_mbps),
-                "p25_recv_rate_mbps": calculate_25th_percentile(net_recv_rate_mbps),
-                "avg_send_rate_interval_mbps": calculate_avg(net_send_rate_mbps),
-                "max_send_rate_mbps": calculate_max(net_send_rate_mbps),
-                "p25_send_rate_mbps": calculate_25th_percentile(net_send_rate_mbps),
+                "avg_recv_rate_interval_mibps": calculate_avg(net_recv_rate_mibps),
+                "max_recv_rate_mibps": calculate_max(net_recv_rate_mibps),
+                "p25_recv_rate_mibps": calculate_25th_percentile(net_recv_rate_mibps),
+                "avg_send_rate_interval_mibps": calculate_avg(net_send_rate_mibps),
+                "max_send_rate_mibps": calculate_max(net_send_rate_mibps),
+                "p25_send_rate_mibps": calculate_25th_percentile(net_send_rate_mibps),
             },
         }
 
@@ -368,26 +368,26 @@ class ResourceMonitor:  # pragma: no cover # logging only
                     if gpu_id < len(s["gpus"])
                 ]
                 gpu_mem_used = [
-                    s["gpus"][gpu_id]["memory_used_gb"]
+                    s["gpus"][gpu_id]["memory_used_gib"]
                     for s in self.samples
                     if gpu_id < len(s["gpus"])
                 ]
                 gpu_mem_total = (
-                    self.samples[0]["gpus"][gpu_id]["memory_total_gb"]
+                    self.samples[0]["gpus"][gpu_id]["memory_total_gib"]
                     if self.samples[0]["gpus"]
                     else 0.0
                 )
 
                 gpu_summary[f"gpu_{gpu_id}"] = {
-                    "memory_total_gb": gpu_mem_total,
+                    "memory_total_gib": gpu_mem_total,
                     "avg_utilization_percent": calculate_avg(gpu_util),
                     "max_utilization_percent": calculate_max(gpu_util),
                     "min_utilization_percent": calculate_min(gpu_util),
                     "p25_utilization_percent": calculate_25th_percentile(gpu_util),
-                    "avg_memory_used_gb": calculate_avg(gpu_mem_used),
-                    "max_memory_used_gb": calculate_max(gpu_mem_used),
-                    "min_memory_used_gb": calculate_min(gpu_mem_used),
-                    "p25_memory_used_gb": calculate_25th_percentile(gpu_mem_used),
+                    "avg_memory_used_gib": calculate_avg(gpu_mem_used),
+                    "max_memory_used_gib": calculate_max(gpu_mem_used),
+                    "min_memory_used_gib": calculate_min(gpu_mem_used),
+                    "p25_memory_used_gib": calculate_25th_percentile(gpu_mem_used),
                 }
             summary["gpus"] = gpu_summary
 
@@ -437,11 +437,11 @@ class ResourceMonitor:  # pragma: no cover # logging only
         summary += lrpad(cpu_row, bounds="|", length=80) + "\n"
 
         # Memory row
-        mem_total = f"{mem['total_gb']:.1f}GB"
-        mem_avg = f"{mem['avg_used_gb']:.1f}GB"
-        mem_max = f"{mem['max_used_gb']:.1f}GB"
-        mem_p25 = f"{mem['p25_used_gb']:.1f}GB"
-        mem_min = f"{mem['min_used_gb']:.1f}GB"
+        mem_total = f"{mem['total_gib']:.1f}GiB"
+        mem_avg = f"{mem['avg_used_gib']:.1f}GiB"
+        mem_max = f"{mem['max_used_gib']:.1f}GiB"
+        mem_p25 = f"{mem['p25_used_gib']:.1f}GiB"
+        mem_min = f"{mem['min_used_gib']:.1f}GiB"
         mem_row = (
             f"{'Memory':<12} {mem_total:>9} {mem_max:>9} {mem_avg:>11} {mem_p25:>11} {mem_min:>11}"
         )
@@ -461,11 +461,11 @@ class ResourceMonitor:  # pragma: no cover # logging only
                 summary += lrpad(gpu_util_row, bounds="|", length=80) + "\n"
 
                 # GPU memory row
-                gpu_mem_total = f"{gpu_stats['memory_total_gb']:.1f}GB"
-                gpu_mem_avg = f"{gpu_stats['avg_memory_used_gb']:.1f}GB"
-                gpu_mem_max = f"{gpu_stats['max_memory_used_gb']:.1f}GB"
-                gpu_mem_p25 = f"{gpu_stats['p25_memory_used_gb']:.1f}GB"
-                gpu_mem_min = f"{gpu_stats['min_memory_used_gb']:.1f}GB"
+                gpu_mem_total = f"{gpu_stats['memory_total_gib']:.1f}GiB"
+                gpu_mem_avg = f"{gpu_stats['avg_memory_used_gib']:.1f}GiB"
+                gpu_mem_max = f"{gpu_stats['max_memory_used_gib']:.1f}GiB"
+                gpu_mem_p25 = f"{gpu_stats['p25_memory_used_gib']:.1f}GiB"
+                gpu_mem_min = f"{gpu_stats['min_memory_used_gib']:.1f}GiB"
                 gpu_mem_row = f"{'GPU ' + gpu_id + ' Mem':<12} {gpu_mem_total:>9} {gpu_mem_max:>9} {gpu_mem_avg:>11} {gpu_mem_p25:>11} {gpu_mem_min:>11}"
                 summary += lrpad(gpu_mem_row, bounds="|", length=80) + "\n"
 
@@ -485,37 +485,37 @@ class ResourceMonitor:  # pragma: no cover # logging only
 
         # Disk Read row
         disk_read_ops = f"{disk_io['total_read_ops']:,}"
-        disk_read_bytes = f"{disk_io['total_read_gb']:.2f}GB"
-        disk_read_rate = f"{disk_io['avg_read_rate_mbps']:.1f}MB/s"
-        disk_read_rate_p25 = f"{disk_io.get('p25_read_rate_mbps', 0):.1f}MB/s"
-        disk_read_rate_max = f"{disk_io.get('max_read_rate_mbps', 0):.1f}MB/s"
+        disk_read_bytes = f"{disk_io['total_read_gib']:.2f}GiB"
+        disk_read_rate = f"{disk_io['avg_read_rate_mibps']:.1f}MiB/s"
+        disk_read_rate_p25 = f"{disk_io.get('p25_read_rate_mibps', 0):.1f}MiB/s"
+        disk_read_rate_max = f"{disk_io.get('max_read_rate_mibps', 0):.1f}MiB/s"
         disk_read_row = f"{'Disk Read':<12} {disk_read_ops:>9} {disk_read_bytes:>9} {disk_read_rate:>11} {disk_read_rate_p25:>11} {disk_read_rate_max:>11}"
         summary += lrpad(disk_read_row, bounds="|", length=80) + "\n"
 
         # Disk Write row
         disk_write_ops = f"{disk_io['total_write_ops']:,}"
-        disk_write_bytes = f"{disk_io['total_write_gb']:.2f}GB"
-        disk_write_rate = f"{disk_io['avg_write_rate_mbps']:.1f}MB/s"
-        disk_write_rate_p25 = f"{disk_io.get('p25_write_rate_mbps', 0):.1f}MB/s"
-        disk_write_rate_max = f"{disk_io.get('max_write_rate_mbps', 0):.1f}MB/s"
+        disk_write_bytes = f"{disk_io['total_write_gib']:.2f}GiB"
+        disk_write_rate = f"{disk_io['avg_write_rate_mibps']:.1f}MiB/s"
+        disk_write_rate_p25 = f"{disk_io.get('p25_write_rate_mibps', 0):.1f}MiB/s"
+        disk_write_rate_max = f"{disk_io.get('max_write_rate_mibps', 0):.1f}MiB/s"
         disk_write_row = f"{'Disk Write':<12} {disk_write_ops:>9} {disk_write_bytes:>9} {disk_write_rate:>11} {disk_write_rate_p25:>11} {disk_write_rate_max:>11}"
         summary += lrpad(disk_write_row, bounds="|", length=80) + "\n"
 
         # Network Receive row
         net_recv_ops = f"{net['total_packets_recv']:,}"
-        net_recv_bytes = f"{net['total_bytes_recv_gb']:.2f}GB"
-        net_recv_rate = f"{net['avg_recv_rate_mbps']:.1f}MB/s"
-        net_recv_rate_p25 = f"{net.get('p25_recv_rate_mbps', 0):.1f}MB/s"
-        net_recv_rate_max = f"{net.get('max_recv_rate_mbps', 0):.1f}MB/s"
+        net_recv_bytes = f"{net['total_bytes_recv_gib']:.2f}GiB"
+        net_recv_rate = f"{net['avg_recv_rate_mibps']:.1f}MiB/s"
+        net_recv_rate_p25 = f"{net.get('p25_recv_rate_mibps', 0):.1f}MiB/s"
+        net_recv_rate_max = f"{net.get('max_recv_rate_mibps', 0):.1f}MiB/s"
         net_recv_row = f"{'Net Receive':<12} {net_recv_ops:>9} {net_recv_bytes:>9} {net_recv_rate:>11} {net_recv_rate_p25:>11} {net_recv_rate_max:>11}"
         summary += lrpad(net_recv_row, bounds="|", length=80) + "\n"
 
         # Network Send row
         net_send_ops = f"{net['total_packets_sent']:,}"
-        net_send_bytes = f"{net['total_bytes_sent_gb']:.2f}GB"
-        net_send_rate = f"{net['avg_send_rate_mbps']:.1f}MB/s"
-        net_send_rate_p25 = f"{net.get('p25_send_rate_mbps', 0):.1f}MB/s"
-        net_send_rate_max = f"{net.get('max_send_rate_mbps', 0):.1f}MB/s"
+        net_send_bytes = f"{net['total_bytes_sent_gib']:.2f}GiB"
+        net_send_rate = f"{net['avg_send_rate_mibps']:.1f}MiB/s"
+        net_send_rate_p25 = f"{net.get('p25_send_rate_mibps', 0):.1f}MiB/s"
+        net_send_rate_max = f"{net.get('max_send_rate_mibps', 0):.1f}MiB/s"
         net_send_row = f"{'Net Send':<12} {net_send_ops:>9} {net_send_bytes:>9} {net_send_rate:>11} {net_send_rate_p25:>11} {net_send_rate_max:>11}"
         summary += lrpad(net_send_row, bounds="|", length=80) + "\n"
 

--- a/zetta_utils/run/costs.py
+++ b/zetta_utils/run/costs.py
@@ -266,12 +266,45 @@ def _aggregate_resource_from_pods(pod_docs: dict) -> dict | None:
         disk = res.get("disk_io", {}) if isinstance(res.get("disk_io"), dict) else {}
         net = res.get("network", {}) if isinstance(res.get("network"), dict) else {}
 
+        # Aggregate GPU stats across all devices on this pod
+        gpus = res.get("gpus", {}) if isinstance(res.get("gpus"), dict) else {}
+        if gpus:
+            gpu_vals = list(gpus.values())
+            gpu_avg_util = (
+                sum(g.get("avg_utilization_percent", 0) for g in gpu_vals) / len(gpu_vals)
+            )
+            gpu_max_util = max(g.get("max_utilization_percent", 0) for g in gpu_vals)
+            gpu_total_mem = sum(g.get("memory_total_gib", 0) for g in gpu_vals)
+            if gpu_total_mem > 0:
+                gpu_avg_mem_pct = (
+                    sum(g.get("avg_memory_used_gib", 0) for g in gpu_vals)
+                    / gpu_total_mem
+                    * 100
+                )
+                gpu_max_mem_pct = (
+                    max(g.get("max_memory_used_gib", 0) for g in gpu_vals)
+                    / (max(g.get("memory_total_gib", 0) for g in gpu_vals) or 1)
+                    * 100
+                )
+            else:
+                gpu_avg_mem_pct = 0.0
+                gpu_max_mem_pct = 0.0
+        else:
+            gpu_avg_util = None
+            gpu_max_util = None
+            gpu_avg_mem_pct = None
+            gpu_max_mem_pct = None
+
         compact = {
             "cpu_avg_percent": cpu.get("avg_percent", 0.0),
             "cpu_max_percent": cpu.get("max_percent", 0.0),
             "mem_avg_percent": mem.get("avg_percent", 0.0),
             "mem_max_percent": mem.get("max_percent", 0.0),
             "mem_max_used_gib": mem.get("max_used_gib", 0.0),
+            "gpu_avg_util_percent": gpu_avg_util,
+            "gpu_max_util_percent": gpu_max_util,
+            "gpu_avg_mem_percent": gpu_avg_mem_pct,
+            "gpu_max_mem_percent": gpu_max_mem_pct,
             "disk_read_gib": disk.get("total_read_gib", 0.0),
             "disk_write_gib": disk.get("total_write_gib", 0.0),
             "net_sent_gib": net.get("total_bytes_sent_gib", 0.0),
@@ -288,7 +321,7 @@ def _aggregate_resource_from_pods(pod_docs: dict) -> dict | None:
     def _fleet_rollup(entries: list[dict]) -> dict:
         if not entries:
             return {}
-        return {
+        result = {
             "avg_cpu_percent": sum(e["cpu_avg_percent"] for e in entries) / len(entries),
             "max_cpu_percent": max(e["cpu_max_percent"] for e in entries),
             "avg_memory_percent": sum(e["mem_avg_percent"] for e in entries) / len(entries),
@@ -296,6 +329,21 @@ def _aggregate_resource_from_pods(pod_docs: dict) -> dict | None:
             "total_net_ingress_gib": sum(e["net_recv_gib"] for e in entries),
             "total_net_egress_gib": sum(e["net_sent_gib"] for e in entries),
         }
+        gpu_entries = [e for e in entries if e.get("gpu_avg_util_percent") is not None]
+        if gpu_entries:
+            result["avg_gpu_util_percent"] = (
+                sum(e["gpu_avg_util_percent"] for e in gpu_entries) / len(gpu_entries)
+            )
+            result["max_gpu_util_percent"] = max(
+                e["gpu_max_util_percent"] for e in gpu_entries
+            )
+            result["avg_gpu_mem_percent"] = (
+                sum(e["gpu_avg_mem_percent"] for e in gpu_entries) / len(gpu_entries)
+            )
+            result["max_gpu_mem_percent"] = max(
+                e["gpu_max_mem_percent"] for e in gpu_entries
+            )
+        return result
 
     return {
         "per_pod": per_pod,
@@ -322,19 +370,25 @@ def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-loca
     W_BN = 17  # bottleneck/2nd
     W_BP = 12  # block/2nd
     W_WL = 21  # wait / lease / ut.
-    W_CA = 6  # cpu avg
-    W_CM = 6  # cpu max
-    W_MA = 6  # mem avg
-    W_MM = 6  # mem max
-    W_NI = 7  # net in
-    W_NO = 7  # net out
+    W_CA = 6   # cpu avg
+    W_CM = 6   # cpu max
+    W_MA = 6   # mem avg
+    W_MM = 6   # mem max
+    W_GU = 6   # gpu util avg
+    W_GX = 6   # gpu util max
+    W_GA = 6   # gpu mem avg
+    W_GK = 6   # gpu mem max
+    W_NI = 7   # net in
+    W_NO = 7   # net out
     # Group widths for top header
     W_SEMA = W_BN + W_BP + W_WL
     W_CPU = W_CA + W_CM
     W_MEM = W_MA + W_MM
+    W_GPU_UTIL = W_GU + W_GX
+    W_GPU_MEM = W_GA + W_GK
     W_NET = W_NI + W_NO
     # 1 leading space + columns + 2 bounds
-    LEN = 1 + W_WT + W_SEMA + W_CPU + W_MEM + W_NET + 2
+    LEN = 1 + W_WT + W_SEMA + W_CPU + W_MEM + W_GPU_UTIL + W_GPU_MEM + W_NET + 2
 
     def _block_pct(entry: dict) -> float:
         tw = entry.get("total_wait_time", 0)
@@ -375,7 +429,7 @@ def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-loca
         return lrpad(text, level=0, length=width + 1, bounds="")
 
     def _row(*cols):
-        widths = (W_WT, W_BN, W_BP, W_WL, W_CA, W_CM, W_MA, W_MM, W_NI, W_NO)
+        widths = (W_WT, W_BN, W_BP, W_WL, W_CA, W_CM, W_MA, W_MM, W_GU, W_GX, W_GA, W_GK, W_NI, W_NO)
         return " " + "".join(_col(c, w) for c, w in zip(cols, widths))
 
     s = ""
@@ -393,6 +447,8 @@ def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-loca
         + _col("(s, bottleneck)", W_WL)
         + _col("CPU", W_CPU)
         + _col("Memory", W_MEM)
+        + _col("CUDA", W_GPU_UTIL)
+        + _col("CUDA Mem", W_GPU_MEM)
         + _col("Network (GiB)", W_NET)
     )
     s += lrpad(top, level=0, bounds="|", length=LEN) + "\n"
@@ -403,6 +459,10 @@ def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-loca
         "Bottleneck/2nd",
         "Block/2nd",
         "Wait / Lease / Ut.",
+        "Avg",
+        "Max",
+        "Avg",
+        "Max",
         "Avg",
         "Max",
         "Avg",
@@ -426,6 +486,26 @@ def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-loca
         mem_max = (
             f"{wt_res['max_memory_percent']:3.0f}%" if "max_memory_percent" in wt_res else "  -"
         )
+        gpu_avg = (
+            f"{wt_res['avg_gpu_util_percent']:3.0f}%"
+            if "avg_gpu_util_percent" in wt_res
+            else "  -"
+        )
+        gpu_max = (
+            f"{wt_res['max_gpu_util_percent']:3.0f}%"
+            if "max_gpu_util_percent" in wt_res
+            else "  -"
+        )
+        gpu_mem_avg = (
+            f"{wt_res['avg_gpu_mem_percent']:3.0f}%"
+            if "avg_gpu_mem_percent" in wt_res
+            else "  -"
+        )
+        gpu_mem_max = (
+            f"{wt_res['max_gpu_mem_percent']:3.0f}%"
+            if "max_gpu_mem_percent" in wt_res
+            else "  -"
+        )
         net_ig = (
             f"{wt_res['total_net_ingress_gib']:.2f}" if "total_net_ingress_gib" in wt_res else "-"
         )
@@ -444,6 +524,10 @@ def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-loca
                     cpu_max,
                     mem_avg,
                     mem_max,
+                    gpu_avg,
+                    gpu_max,
+                    gpu_mem_avg,
+                    gpu_mem_max,
                     net_ig,
                     net_eg,
                 ),

--- a/zetta_utils/run/costs.py
+++ b/zetta_utils/run/costs.py
@@ -5,6 +5,7 @@ from copy import copy
 from typing import Final
 
 from zetta_utils.cloud_management.resource_allocation import gcloud
+from zetta_utils.common.pprint import lrpad
 from zetta_utils.layer.db_layer.backend import DBRowDataT
 from zetta_utils.layer.db_layer.firestore import build_firestore_layer
 from zetta_utils.layer.db_layer.layer import DBLayer
@@ -268,12 +269,13 @@ def _aggregate_resource_from_pods(pod_docs: dict) -> dict | None:
         compact = {
             "cpu_avg_percent": cpu.get("avg_percent", 0.0),
             "cpu_max_percent": cpu.get("max_percent", 0.0),
+            "mem_avg_percent": mem.get("avg_percent", 0.0),
             "mem_max_percent": mem.get("max_percent", 0.0),
-            "mem_max_used_gb": mem.get("max_used_gb", 0.0),
-            "disk_read_gb": disk.get("total_read_gb", 0.0),
-            "disk_write_gb": disk.get("total_write_gb", 0.0),
-            "net_sent_gb": net.get("total_bytes_sent_gb", 0.0),
-            "net_recv_gb": net.get("total_bytes_recv_gb", 0.0),
+            "mem_max_used_gib": mem.get("max_used_gib", 0.0),
+            "disk_read_gib": disk.get("total_read_gib", 0.0),
+            "disk_write_gib": disk.get("total_write_gib", 0.0),
+            "net_sent_gib": net.get("total_bytes_sent_gib", 0.0),
+            "net_recv_gib": net.get("total_bytes_recv_gib", 0.0),
         }
         pod_name = doc_key.split("__", 1)[1] if "__" in doc_key else doc_key
         per_pod[pod_name] = compact
@@ -288,8 +290,11 @@ def _aggregate_resource_from_pods(pod_docs: dict) -> dict | None:
             return {}
         return {
             "avg_cpu_percent": sum(e["cpu_avg_percent"] for e in entries) / len(entries),
+            "max_cpu_percent": max(e["cpu_max_percent"] for e in entries),
+            "avg_memory_percent": sum(e["mem_avg_percent"] for e in entries) / len(entries),
             "max_memory_percent": max(e["mem_max_percent"] for e in entries),
-            "total_net_egress_gb": sum(e["net_sent_gb"] for e in entries),
+            "total_net_ingress_gib": sum(e["net_recv_gib"] for e in entries),
+            "total_net_egress_gib": sum(e["net_sent_gib"] for e in entries),
         }
 
     return {
@@ -299,6 +304,159 @@ def _aggregate_resource_from_pods(pod_docs: dict) -> dict | None:
             wt: _fleet_rollup(entries) for wt, entries in per_worker_entries.items()
         },
     }
+
+
+def _log_worker_type_table(  # pragma: no cover  # pylint: disable=too-many-locals,too-many-statements
+    sema: dict | None,
+    resource: dict | None,
+) -> None:
+    """Log a per-worker-type table of bottleneck, CPU, and memory stats."""
+    sema_by_wt = sema.get("per_worker_type", {}) if sema else {}
+    res_by_wt = resource.get("per_worker_type", {}) if resource else {}
+    worker_types = sorted(set(sema_by_wt) | set(res_by_wt))
+    if not worker_types:
+        return
+
+    # Column widths (logical; _col adds 1 to compensate for lrpad bounds="" quirk)
+    W_WT = 18  # worker type
+    W_BN = 17  # bottleneck/2nd
+    W_BP = 12  # block/2nd
+    W_WL = 21  # wait / lease / ut.
+    W_CA = 6  # cpu avg
+    W_CM = 6  # cpu max
+    W_MA = 6  # mem avg
+    W_MM = 6  # mem max
+    W_NI = 7  # net in
+    W_NO = 7  # net out
+    # Group widths for top header
+    W_SEMA = W_BN + W_BP + W_WL
+    W_CPU = W_CA + W_CM
+    W_MEM = W_MA + W_MM
+    W_NET = W_NI + W_NO
+    # 1 leading space + columns + 2 bounds
+    LEN = 1 + W_WT + W_SEMA + W_CPU + W_MEM + W_NET + 2
+
+    def _block_pct(entry: dict) -> float:
+        tw = entry.get("total_wait_time", 0)
+        tl = entry.get("total_lease_time", 0)
+        return tw / (tw + tl) * 100 if (tw + tl) > 0 else 0
+
+    def _fmt_sema(wt_sema: dict) -> tuple[str, str, str]:
+        """Returns (bottleneck(2nd), block(2nd), wait_lease_ut_str)."""
+        bn = wt_sema.get("bottleneck") or "-"
+        per_type = wt_sema.get("per_type", {})
+        if bn != "-" and bn in per_type:
+            entry = per_type[bn]
+            wait_pct = _block_pct(entry)
+            avg_w = entry.get("avg_wait", 0)
+            avg_l = entry.get("avg_lease", 0)
+            util = entry.get("utilization_pct")
+            wl = f"{avg_w:.2f} / {avg_l:.2f}"
+            if util is not None:
+                wl += f" / {util:.0f}%"
+            # Find 2nd bottleneck
+            others = [
+                (k, _block_pct(v))
+                for k, v in per_type.items()
+                if k != bn and (v.get("total_wait_time", 0) + v.get("total_lease_time", 0)) > 0
+            ]
+            if others:
+                others.sort(key=lambda x: x[1], reverse=True)
+                s_name, s_pct = others[0]
+                bn_str = f"{bn} / {s_name}"
+                bp_str = f"{wait_pct:2.0f}% / {s_pct:2.0f}%"
+            else:
+                bn_str = bn
+                bp_str = f"{wait_pct:2.0f}%"
+            return bn_str, bp_str, wl
+        return bn, "-", "-"
+
+    def _col(text, width):
+        return lrpad(text, level=0, length=width + 1, bounds="")
+
+    def _row(*cols):
+        widths = (W_WT, W_BN, W_BP, W_WL, W_CA, W_CM, W_MA, W_MM, W_NI, W_NO)
+        return " " + "".join(_col(c, w) for c, w in zip(cols, widths))
+
+    s = ""
+    title = "  Worker Stats by Type  "
+    pad_total = LEN - 2 - len(title)  # space between + bounds
+    pad_left = pad_total // 2
+    s += lrpad("=" * pad_left + title, level=0, bounds="+", filler="=", length=LEN) + "\n"
+    s += lrpad("", level=0, bounds="|", length=LEN) + "\n"
+
+    # Top header — group names with (s) above Wait/Lease/Ut.
+    top = (
+        " "
+        + _col("", W_WT)
+        + _col("Semaphores", W_BN + W_BP)
+        + _col("(s, bottleneck)", W_WL)
+        + _col("CPU", W_CPU)
+        + _col("Memory", W_MEM)
+        + _col("Network (GiB)", W_NET)
+    )
+    s += lrpad(top, level=0, bounds="|", length=LEN) + "\n"
+
+    # Bottom header — column names
+    bottom = _row(
+        "Worker Type",
+        "Bottleneck/2nd",
+        "Block/2nd",
+        "Wait / Lease / Ut.",
+        "Avg",
+        "Max",
+        "Avg",
+        "Max",
+        "In",
+        "Out",
+    )
+    s += lrpad(bottom, level=0, bounds="|", length=LEN) + "\n"
+    s += lrpad("", level=0, filler="-", bounds="|", length=LEN) + "\n"
+
+    for wt in worker_types:
+        wt_sema_data = sema_by_wt.get(wt, {})
+        wt_res = res_by_wt.get(wt, {})
+
+        bn_str, bp_str, wl_detail = _fmt_sema(wt_sema_data) if wt_sema_data else ("-", "-", "-")
+        cpu_avg = f"{wt_res['avg_cpu_percent']:3.0f}%" if "avg_cpu_percent" in wt_res else "  -"
+        cpu_max = f"{wt_res['max_cpu_percent']:3.0f}%" if "max_cpu_percent" in wt_res else "  -"
+        mem_avg = (
+            f"{wt_res['avg_memory_percent']:3.0f}%" if "avg_memory_percent" in wt_res else "  -"
+        )
+        mem_max = (
+            f"{wt_res['max_memory_percent']:3.0f}%" if "max_memory_percent" in wt_res else "  -"
+        )
+        net_ig = (
+            f"{wt_res['total_net_ingress_gib']:.2f}" if "total_net_ingress_gib" in wt_res else "-"
+        )
+        net_eg = (
+            f"{wt_res['total_net_egress_gib']:.2f}" if "total_net_egress_gib" in wt_res else "-"
+        )
+
+        s += (
+            lrpad(
+                _row(
+                    wt[:W_WT],
+                    bn_str,
+                    bp_str,
+                    wl_detail,
+                    cpu_avg,
+                    cpu_max,
+                    mem_avg,
+                    mem_max,
+                    net_ig,
+                    net_eg,
+                ),
+                level=0,
+                bounds="|",
+                length=LEN,
+            )
+            + "\n"
+        )
+
+    s += lrpad("", level=0, bounds="|", length=LEN) + "\n"
+    s += lrpad("", level=0, bounds="+", filler="=", length=LEN)
+    logger.info(s)
 
 
 def aggregate_pod_stats(
@@ -335,7 +493,6 @@ def aggregate_pod_stats(
 
     if gcs is not None:
         bottleneck = sema.get("bottleneck") if sema else None
-        fleet = resource.get("fleet", {}) if resource else {}
         _current = (
             gcs["total_class_a"],
             gcs["total_class_b"],
@@ -350,22 +507,14 @@ def aggregate_pod_stats(
                 if _last_compute_cost is not None
                 else ""
             )
-            extras = []
-            if bottleneck:
-                extras.append(f"bottleneck={bottleneck}")
-            if "avg_cpu_percent" in fleet:
-                extras.append(f"cpu={fleet['avg_cpu_percent']:.0f}%")
-            if "max_memory_percent" in fleet:
-                extras.append(f"mem_max={fleet['max_memory_percent']:.0f}%")
-            extras_str = " | " + " ".join(extras) if extras else ""
             logger.info(
                 f"{cost_str}"
                 f"gcs stats: A={gcs['total_class_a']} "
                 f"B={gcs['total_class_b']} egress={update['total_egress_gib']:.2f} GiB "
                 f"(${gcs['egress_cost_min']:.2f}-${gcs['egress_cost_max']:.2f}) "
                 f"from {gcs['pod_count']} pods, {len(gcs['buckets'])} buckets"
-                f"{extras_str}"
             )
+            _log_worker_type_table(sema, resource)
 
     return update
 


### PR DESCRIPTION
Replace the single-line bottleneck/cpu/mem summary with a formatted table showing per-worker-type breakdown of semaphore bottlenecks (1st and 2nd), block %, wait/lease/utilization times, CPU avg/max, memory avg/max, and network ingress/egress.

Also rename all _gb/_mbps suffixes to _gib/_mibps throughout resource_monitor.py and costs.py to correctly reflect binary units (division by 1024^n), and add avg_memory_percent and max_cpu_percent to the per-worker-type fleet rollup.